### PR TITLE
Resolve backup provisioner cert issues since postgres on alpine 3.12.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bin/*
+.kubeconfig

--- a/deploy/postgres.yaml
+++ b/deploy/postgres.yaml
@@ -68,7 +68,9 @@ spec:
         args:
         - sh
         - -c
-        - mkdir -p /data/postgres && backup-restore-sidecar start --log-level debug
+        - |
+          apk add /pkg-provision/*
+          mkdir -p /data/postgres && backup-restore-sidecar start --log-level debug
         env:
         - name: BACKUP_RESTORE_SIDECAR_GCP_PROJECT
           valueFrom:
@@ -103,6 +105,8 @@ spec:
         - name: bin-provision
           subPath: backup-restore-sidecar
           mountPath: /usr/local/bin/backup-restore-sidecar
+        - name: pkg-provision
+          mountPath: /pkg-provision
         - name: backup-restore-sidecar-config
           mountPath: /etc/backup-restore-sidecar
         - name: bin-provision
@@ -116,19 +120,22 @@ spec:
         image: metalstack/backup-restore-sidecar:latest
         imagePullPolicy: IfNotPresent
         command:
-        - cp
-        - /backup-restore-sidecar
-        - /sbin/tini
-        - /bin-provision
+        - sh
+        - -c
+        - |
+          cp /backup-restore-sidecar /sbin/tini /bin-provision
+          cp /pkgs/* /pkg-provision
         volumeMounts:
         - name: bin-provision
           mountPath: /bin-provision
+        - name: pkg-provision
+          mountPath: /pkg-provision
       volumes:
       - name: postgres
         persistentVolumeClaim:
           claimName: postgres
       - name: backup-restore-sidecar-config
-        configMap: 
+        configMap:
           name: backup-restore-sidecar-config-postgres
       - name: gcp-credentials
         secret:
@@ -137,6 +144,8 @@ spec:
           - key: serviceaccount.json
             path: serviceaccount.json
       - name: bin-provision
+        emptyDir: {}
+      - name: pkg-provision
         emptyDir: {}
   volumeClaimTemplates:
   - metadata:


### PR DESCRIPTION
Since the latest `postgres:12-alpine` docker image release we get a certificate error from the backup-restore-sidecar (when the GCP provisioner tries to connect to the bucket store).

Somehow, in a prior version of `postgres:12-alpine`, we can find ca certificates in `/etc/ssl/cert.pem`:

```bash
docker run --rm -it --entrypoint sh postgres@sha256:9ea72265275674225b1eaa2ae897dd244028af4ee7ef6e4e89fe474938e0992e
...
/ # cat /etc/ssl/cert.pem 
-----BEGIN CERTIFICATE-----
MIIH0zCCBbugAwIBAgIIXsO3pkN/pOAwDQYJKoZIhvcNAQEFBQAwQjESMBAGA1UE
...
/ # cat /etc/os-release 
NAME="Alpine Linux"
ID=alpine
VERSION_ID=3.11.6
PRETTY_NAME="Alpine Linux v3.11"
HOME_URL="https://alpinelinux.org/"
BUG_REPORT_URL="https://bugs.alpinelinux.org/"
```

In the latest `postgres:12-alpine`, this file is a dead symlink and we have alpine 3.12:

```bash
/ # ls -l /etc/ssl/cert.pem 
lrwxrwxrwx    1 root     root            25 May 29 14:20 /etc/ssl/cert.pem -> certs/ca-certificates.crt
/ # cat /etc/os-release 
NAME="Alpine Linux"
ID=alpine
VERSION_ID=3.12.0
PRETTY_NAME="Alpine Linux v3.12"
HOME_URL="https://alpinelinux.org/"
BUG_REPORT_URL="https://bugs.alpinelinux.org/"
```

Installing `ca-certificates` in `postgres:12-alpine` will make everything work again as before.

In order to resolve this issue, I added a `pkg-provision` volume and download the `.apk` file during build time. The package will then be installed dynamically on start in the entrypoint script into the `postgres:12-alpine` image. Note that the backup restore sidecar runs within the target database container and an init container only injects stuff in order to keep maintenance overhead as small as possible. 

I know, it's not the nicest way of doing things, but to me it seems more comfortable than starting to maintain own images of `postgres:alpine` or installing database clients for every database we support into the backup-restore-sidecar at build time. This way, we are still relatively flexible for introducing other databases without too much download and maintenance complexity.