### PR TITLE
add metrics endpoint

### DIFF
--- a/cmd/internal/metrics/metrics.go
+++ b/cmd/internal/metrics/metrics.go
@@ -1,0 +1,91 @@
+package metrics
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.uber.org/zap"
+)
+
+//Metrics contains the collected metrics
+type Metrics struct {
+	totalBackups  prometheus.Counter
+	backupSuccess prometheus.Gauge
+	backupSize    prometheus.Gauge
+	totalErrors   *prometheus.CounterVec
+}
+
+//New generates new metrics
+func New() *Metrics {
+	backupSuccess := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "backup_success",
+		Help: "return code of last backup",
+	},
+	)
+
+	totalBackups := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "backup_total_backups",
+		Help: "total number of successfull backups",
+	},
+	)
+
+	totalErrors := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "backup_errors",
+		Help: "total number of errors during backups",
+	},
+		[]string{"operation"},
+	)
+
+	backupSize := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "backup_size",
+		Help: "size of last backup in bytes",
+	},
+	)
+
+	return &Metrics{
+		totalBackups:  totalBackups,
+		backupSuccess: backupSuccess,
+		totalErrors:   totalErrors,
+		backupSize:    backupSize,
+	}
+}
+
+// Start starts the metrics server
+func (m *Metrics) Start(log *zap.SugaredLogger) {
+	log.Info("starting metrics server")
+	http.Handle("/metrics", promhttp.Handler())
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`<html>
+			<head><title>backup-restore metrics</title></head>
+			<body>
+			<h1>backup-restore metrics</h1>
+			<p><a href='/metrics'>Metrics</a></p </body </html>`))
+	})
+
+	prometheus.MustRegister(m.backupSuccess)
+	prometheus.MustRegister(m.totalBackups)
+	prometheus.MustRegister(m.totalErrors)
+	prometheus.MustRegister(m.backupSize)
+
+	go func() {
+		if err := http.ListenAndServe(":2112", nil); err != nil {
+			log.Fatal(err)
+		}
+	}()
+}
+
+//CountBackup updates metrics counter
+func (m *Metrics) CountBackup(backupFile string) {
+	s, _ := os.Stat(backupFile)
+	m.totalBackups.Inc()
+	m.backupSuccess.Set(1)
+	m.backupSize.Set(float64(s.Size()))
+}
+
+//CountError increases error counter for the given operation
+func (m *Metrics) CountError(op string) {
+	m.totalErrors.With(prometheus.Labels{"operation": op}).Inc()
+	m.backupSuccess.Set(0)
+}

--- a/cmd/internal/metrics/metrics.go
+++ b/cmd/internal/metrics/metrics.go
@@ -21,13 +21,13 @@ type Metrics struct {
 func New() *Metrics {
 	backupSuccess := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "backup_success",
-		Help: "return code of last backup",
+		Help: "is 0 when the last backup was successful, otherwise 1",
 	},
 	)
 
 	totalBackups := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "backup_total_backups",
-		Help: "total number of successfull backups",
+		Help: "total number of successful backups",
 	},
 	)
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/metal-stack/backup-restore-sidecar/cmd/internal/database/postgres"
 	"github.com/metal-stack/backup-restore-sidecar/cmd/internal/database/rethinkdb"
 	"github.com/metal-stack/backup-restore-sidecar/cmd/internal/initializer"
+	"github.com/metal-stack/backup-restore-sidecar/cmd/internal/metrics"
 	"github.com/metal-stack/backup-restore-sidecar/cmd/internal/probe"
 	"github.com/metal-stack/backup-restore-sidecar/cmd/internal/signals"
 	"github.com/metal-stack/backup-restore-sidecar/cmd/internal/utils"
@@ -98,7 +99,9 @@ var startCmd = &cobra.Command{
 		if err := probe.Start(logger.Named("probe"), db, stop); err != nil {
 			return err
 		}
-		return backup.Start(logger.Named("backup"), viper.GetString(backupCronScheduleFlg), db, bp, stop)
+		metrics := metrics.New()
+		metrics.Start(logger.Named("metrics"))
+		return backup.Start(logger.Named("backup"), viper.GetString(backupCronScheduleFlg), db, bp, metrics, stop)
 	},
 }
 

--- a/deploy/postgres.yaml
+++ b/deploy/postgres.yaml
@@ -120,6 +120,8 @@ spec:
         - /backup-restore-sidecar
         - /sbin/tini
         - /bin-provision
+        ports:
+        - containerPort: 2112
         volumeMounts:
         - name: bin-provision
           mountPath: /bin-provision
@@ -181,5 +183,8 @@ spec:
   - name: "5432"
     port: 5432
     targetPort: 5432
+  - name: "metrics"
+    port: 2112
+    targetPort: 2112
   selector:
     app: postgres

--- a/deploy/rethinkdb.yaml
+++ b/deploy/rethinkdb.yaml
@@ -107,6 +107,8 @@ spec:
         - /rethinkdb/rethinkdb-dump
         - /rethinkdb/rethinkdb-restore
         - /bin-provision
+        ports:
+        - containerPort: 2112
         volumeMounts:
         - name: bin-provision
           mountPath: /bin-provision
@@ -178,5 +180,8 @@ spec:
   - name: "28015"
     port: 28015
     targetPort: 28015
+  - name: "metrics"
+    port: 2112
+    targetPort: 2112
   selector:
     app: rethinkdb

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/pelletier/go-toml v1.8.0 // indirect
 	github.com/pierrec/lz4 v2.5.2+incompatible // indirect
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v0.9.3
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/afero v1.3.0 // indirect
 	github.com/spf13/cast v1.3.1 // indirect


### PR DESCRIPTION
adds a /metrics endpoint to the sidecar, with following metrics

```bash
kubectl port-forward svc/postgres 2112 &

curl -s 127.0.0.1:2112/metrics |grep backup
# HELP backup_errors total number of errors during backups
# TYPE backup_errors counter
backup_errors{operation="create"} 2
backup_errors{operation="upload"} 1
# HELP backup_size size of last backup in bytes
# TYPE backup_size gauge
backup_size 2.755029e+06
# HELP backup_success return code of last backup
# TYPE backup_success gauge
backup_success 1
# HELP backup_total_backups total number of successfull backups
# TYPE backup_total_backups counter
backup_total_backups 15

```



Fixes #13