### PR TITLE
Only link libgcc and libstdc++ statically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GO111MODULE := on
 CGO_ENABLED := 1
-LINKMODE := -linkmode external -extldflags '-static -s -w'
+LINKMODE := -linkmode external -extldflags '-static-libgcc -static-libstdc++ -s -w'
 DOCKER_TAG := $(or ${GITHUB_TAG_NAME}, latest)
 
 .PHONY: all


### PR DESCRIPTION
We're having this issue: https://github.com/golang/go/issues/13470

This seems to be what coackroach is doing as well. It somehow works after that and also the warnings are gone during the build.