### PR TITLE
Binary does not run on Alpine anymore.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GO111MODULE := on
 CGO_ENABLED := 1
-LINKMODE := -linkmode external -extldflags '-static -s -w'
+LINKMODE := -extldflags '-static -s -w'
 DOCKER_TAG := $(or ${GITHUB_TAG_NAME}, latest)
 
 .PHONY: all

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 GO111MODULE := on
 CGO_ENABLED := 1
-LINKMODE := -linkmode external -extldflags '-static-libgcc -static-libstdc++ -s -w'
+LINKMODE := -linkmode external -extldflags '-static -s -w'
 DOCKER_TAG := $(or ${GITHUB_TAG_NAME}, latest)
 
 .PHONY: all
 all:
 	go mod tidy
-	go build -tags netgo -ldflags "$(LINKMODE)" -o bin/backup-restore-sidecar github.com/metal-stack/backup-restore-sidecar/cmd
+	go build -ldflags "$(LINKMODE)" -tags 'osusergo netgo static_build' -o bin/backup-restore-sidecar github.com/metal-stack/backup-restore-sidecar/cmd
 	strip bin/backup-restore-sidecar
 
 .PHONY: proto


### PR DESCRIPTION
Since the last PR we can't run the binary on Alpine anymore, but it works fine with rethinkdb...

I added the `osusergo` flag, which seemed reasonable to me because we had errors with user system libraries before. This enforces pure go implementation as can be read here https://godoc.org/github.com/golang/go/src/os/user.