### PR TITLE
Remove client dial loop.

### DIFF
--- a/cmd/internal/initializer/client.go
+++ b/cmd/internal/initializer/client.go
@@ -11,7 +11,7 @@ import (
 )
 
 // NewInitializerClient returns a new initializer client.
-func NewInitializerClient(ctx context.Context, rawurl string, log *zap.SugaredLogger, stop <-chan struct{}) (v1.InitializerServiceClient, error) {
+func NewInitializerClient(ctx context.Context, rawurl string, log *zap.SugaredLogger) (v1.InitializerServiceClient, error) {
 	parsedurl, err := url.Parse(rawurl)
 	if err != nil {
 		return nil, err

--- a/cmd/internal/wait/wait.go
+++ b/cmd/internal/wait/wait.go
@@ -17,7 +17,7 @@ const (
 func Start(log *zap.SugaredLogger, addr string, stop <-chan struct{}) error {
 	ctx, cancel := context.WithTimeout(context.TODO(), 3*time.Second)
 	defer cancel()
-	client, err := initializer.NewInitializerClient(ctx, addr, log, stop)
+	client, err := initializer.NewInitializerClient(ctx, addr, log)
 	if err != nil {
 		return err
 	}

--- a/cmd/internal/wait/wait.go
+++ b/cmd/internal/wait/wait.go
@@ -17,7 +17,7 @@ const (
 func Start(log *zap.SugaredLogger, addr string, stop <-chan struct{}) error {
 	ctx, cancel := context.WithTimeout(context.TODO(), 3*time.Second)
 	defer cancel()
-	client, err := initializer.NewInitializerClientWithRetry(ctx, addr, log, stop)
+	client, err := initializer.NewInitializerClient(ctx, addr, log, stop)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
`WithBlock` waits for connection anyway. Also, when an error happens there, it's better to just die and let Kubernetes restart the container.

References #21.