### PR TITLE
Also copy postgres binary in backup step.

### DIFF
--- a/cmd/internal/database/postgres/postgres.go
+++ b/cmd/internal/database/postgres/postgres.go
@@ -65,7 +65,7 @@ func (db *Postgres) Backup() error {
 	// therefore this happens in the backup task where the database is already available
 	//
 	// implication: one backup has to be taken before an upgrade can be made
-	err := db.copyPostgresBinaries()
+	err := db.copyPostgresBinaries(false)
 	if err != nil {
 		return err
 	}

--- a/cmd/internal/database/postgres/postgres.go
+++ b/cmd/internal/database/postgres/postgres.go
@@ -61,6 +61,15 @@ func (db *Postgres) Check() (bool, error) {
 
 // Backup takes a backup of the database
 func (db *Postgres) Backup() error {
+	// for new databases the postgres binaries required for Upgrade() cannot be copied before the database is running
+	// therefore this happens in the backup task where the database is already available
+	//
+	// implication: one backup has to be taken before an upgrade can be made
+	err := db.copyPostgresBinaries()
+	if err != nil {
+		return err
+	}
+
 	if err := os.RemoveAll(constants.BackupDir); err != nil {
 		return fmt.Errorf("could not clean backup directory: %w", err)
 	}

--- a/cmd/internal/database/postgres/upgrade.go
+++ b/cmd/internal/database/postgres/upgrade.go
@@ -42,12 +42,6 @@ func (db *Postgres) Upgrade() error {
 		return nil
 	}
 
-	// If this is a database directory, save actual postgres binaries for a later major upgrade
-	err := db.copyPostgresBinaries()
-	if err != nil {
-		return err
-	}
-
 	// Check if required commands are present
 	for _, command := range requiredCommands {
 		if ok := db.isCommandPresent(command); !ok {
@@ -84,7 +78,7 @@ func (db *Postgres) Upgrade() error {
 	// Check if old pg_config are present and match pgVersion
 	oldPostgresConfigCmd := path.Join(oldPostgresBinDir, postgresConfigCmd)
 	if ok := db.isCommandPresent(oldPostgresConfigCmd); !ok {
-		db.log.Infof("%q is not present, skipping upgrade", oldPostgresConfigCmd)
+		db.log.Infof("%q is not present, please make sure that at least one backup was taken with the old postgres version before running an upgrade, skipping upgrade", oldPostgresConfigCmd)
 		return nil
 	}
 
@@ -264,6 +258,7 @@ func (db *Postgres) getBinDir(pgConfigCmd string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
+// copyPostgresBinaries is needed to save old postgres binaries for a later major upgrade
 func (db *Postgres) copyPostgresBinaries() error {
 	binDir, err := db.getBinDir(postgresConfigCmd)
 	if err != nil {

--- a/cmd/internal/database/postgres/upgrade.go
+++ b/cmd/internal/database/postgres/upgrade.go
@@ -271,19 +271,19 @@ func (db *Postgres) copyPostgresBinaries(override bool) error {
 		return err
 	}
 
-	if !override {
-		if _, err := os.Stat(path.Join(binDir, postgresConfigCmd)); err == nil {
-			db.log.Info("postgres binaries for later upgrade already in place, not copying")
-			return nil
-		}
-	}
-
 	version, err := db.getBinaryVersion(postgresConfigCmd)
 	if err != nil {
 		return err
 	}
 
 	pgBinDir := path.Join(db.datadir, fmt.Sprintf("%s%d", postgresBinBackupPrefix, version))
+
+	if !override {
+		if _, err := os.Stat(path.Join(pgBinDir, postgresConfigCmd)); err == nil {
+			db.log.Info("postgres binaries for later upgrade already in place, not copying")
+			return nil
+		}
+	}
 
 	err = os.RemoveAll(pgBinDir)
 	if err != nil {

--- a/cmd/internal/database/postgres/upgrade.go
+++ b/cmd/internal/database/postgres/upgrade.go
@@ -42,6 +42,12 @@ func (db *Postgres) Upgrade() error {
 		return nil
 	}
 
+	// If this is a database directory, save actual postgres binaries for a later major upgrade
+	err := db.copyPostgresBinaries()
+	if err != nil {
+		return err
+	}
+
 	// Check if required commands are present
 	for _, command := range requiredCommands {
 		if ok := db.isCommandPresent(command); !ok {
@@ -78,7 +84,7 @@ func (db *Postgres) Upgrade() error {
 	// Check if old pg_config are present and match pgVersion
 	oldPostgresConfigCmd := path.Join(oldPostgresBinDir, postgresConfigCmd)
 	if ok := db.isCommandPresent(oldPostgresConfigCmd); !ok {
-		db.log.Infof("%q is not present, please make sure that at least one backup was taken with the old postgres version before running an upgrade, skipping upgrade", oldPostgresConfigCmd)
+		db.log.Infof("%q is not present, please make sure that at least one backup was taken with the old postgres version or restart the backup-restore-sidecar container with the old postgres version before running an upgrade, skipping upgrade", oldPostgresConfigCmd)
 		return nil
 	}
 


### PR DESCRIPTION
This has the advantage that no pod restart needs to be issued before running an upgrade on a fresh database.