### PR TITLE
fix(meili): wait more patiently

### DIFF
--- a/cmd/internal/database/meilisearch/meilisearch.go
+++ b/cmd/internal/database/meilisearch/meilisearch.go
@@ -82,7 +82,7 @@ func (db *Meilisearch) Backup(ctx context.Context) error {
 
 	dumpTask, err := db.client.WaitForTask(dumpResponse.TaskUID, meilisearch.WaitParams{
 		Context:  ctx,
-		Interval: time.Millisecond * 50,
+		Interval: time.Second,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Doing a backup of a meilisearch index takes much longer than a second.