### PR TITLE
Use individual lifecycle policies per object prefix to allow sidecars to act on a single bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The backups are stored at the storage provider with the `.aes` suffix. If the fi
 - The database is deployed as a statefulset and the data is backed by a PVC
 - No "Point in Time Recovery" (PITR)
 
-## Using Multiple Backup-Restore-Sidecars
+## Using Multiple Backup-Restore-Sidecars On a Single Bucket
 
 It is possible to let multiple backup-restore-sidecars (for different databases) use the same backup bucket at an external provider. However, it has to be noted that these sidecars must all configure a dedicated object prefix in which they store the backups. Otherwise they would overwrite each other's data.
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ The backups are stored at the storage provider with the `.aes` suffix. If the fi
 - The database is deployed as a statefulset and the data is backed by a PVC
 - No "Point in Time Recovery" (PITR)
 
+## Using Multiple Backup-Restore-Sidecars
+
+It is possible to let multiple backup-restore-sidecars (for different databases) use the same backup bucket at an external provider. However, it has to be noted that these sidecars must all configure a dedicated object prefix in which they store the backups. Otherwise they would overwrite each other's data.
+
+Be aware that, if you change the object prefix under which the backups are stored, the old lifecycle policies matching this prefix are not automatically cleaned up and have to be removed manually.
+
 ## Try it out
 
 Requires:

--- a/cmd/internal/backup/providers/s3/s3.go
+++ b/cmd/internal/backup/providers/s3/s3.go
@@ -132,30 +132,36 @@ func (b *BackupProviderS3) EnsureBackupBucket(ctx context.Context) error {
 		return err
 	}
 
+	rules := []types.LifecycleRule{
+		{
+			NoncurrentVersionExpiration: &types.NoncurrentVersionExpiration{
+				NewerNoncurrentVersions: &b.config.ObjectsToKeep,
+			},
+			Status: types.ExpirationStatusEnabled,
+			ID:     aws.String(b.config.ObjectPrefix + "-backup-restore-lifecycle"),
+			Filter: &types.LifecycleRuleFilter{
+				Prefix: aws.String(b.config.ObjectPrefix),
+			},
+		},
+	}
+
 	// get existing lifecycle configuration
 	bucketLifecycleConfiguration, err := b.c.GetBucketLifecycleConfiguration(ctx, &s3.GetBucketLifecycleConfigurationInput{
 		Bucket: aws.String(b.config.BucketName),
 	})
-	if err != nil {
-		return err
-	}
 
-	lifecycleRule := types.LifecycleRule{
-		NoncurrentVersionExpiration: &types.NoncurrentVersionExpiration{
-			NewerNoncurrentVersions: &b.config.ObjectsToKeep,
-		},
-		Status: types.ExpirationStatusEnabled,
-		ID:     aws.String(b.config.ObjectPrefix + "-backup-restore-lifecycle"),
-		Filter: &types.LifecycleRuleFilter{
-			Prefix: aws.String(b.config.ObjectPrefix),
-		},
+	if bucketLifecycleConfiguration != nil {
+		if err != nil {
+			return err
+		}
+		rules = append(rules, bucketLifecycleConfiguration.Rules...)
 	}
 
 	// add lifecycle policy
 	_, err = b.c.PutBucketLifecycleConfiguration(ctx, &s3.PutBucketLifecycleConfigurationInput{
 		Bucket: aws.String(b.config.BucketName),
 		LifecycleConfiguration: &types.BucketLifecycleConfiguration{
-			Rules: append(bucketLifecycleConfiguration.Rules, lifecycleRule),
+			Rules: rules,
 		},
 	})
 	if err != nil {

--- a/cmd/internal/backup/providers/s3/s3.go
+++ b/cmd/internal/backup/providers/s3/s3.go
@@ -139,10 +139,10 @@ func (b *BackupProviderS3) EnsureBackupBucket(ctx context.Context) error {
 			Rules: []types.LifecycleRule{
 				{
 					NoncurrentVersionExpiration: &types.NoncurrentVersionExpiration{
-						NoncurrentDays: &b.config.ObjectsToKeep,
+						NewerNoncurrentVersions: &b.config.ObjectsToKeep,
 					},
 					Status: types.ExpirationStatusEnabled,
-					ID:     aws.String("backup-restore-lifecycle"),
+					ID:     aws.String(b.config.ObjectPrefix + "backup-restore-lifecycle"),
 					Filter: &types.LifecycleRuleFilter{
 						Prefix: aws.String(b.config.ObjectPrefix),
 					},

--- a/cmd/internal/backup/providers/s3/s3.go
+++ b/cmd/internal/backup/providers/s3/s3.go
@@ -142,7 +142,7 @@ func (b *BackupProviderS3) EnsureBackupBucket(ctx context.Context) error {
 			Status: types.ExpirationStatusEnabled,
 			ID:     lifecycleRuleID,
 			Filter: &types.LifecycleRuleFilter{
-				Prefix: aws.String(b.config.ObjectPrefix),
+				Prefix: aws.String(b.config.ObjectPrefix + "/"),
 			},
 		},
 	}

--- a/cmd/internal/backup/providers/s3/s3.go
+++ b/cmd/internal/backup/providers/s3/s3.go
@@ -142,10 +142,7 @@ func (b *BackupProviderS3) EnsureBackupBucket(ctx context.Context) error {
 						NewerNoncurrentVersions: &b.config.ObjectsToKeep,
 					},
 					Status: types.ExpirationStatusEnabled,
-					ID:     aws.String(b.config.ObjectPrefix + "backup-restore-lifecycle"),
-					Filter: &types.LifecycleRuleFilter{
-						Prefix: aws.String(b.config.ObjectPrefix),
-					},
+					ID:     aws.String("backup-restore-lifecycle"),
 				},
 			},
 		},

--- a/cmd/internal/backup/providers/s3/s3.go
+++ b/cmd/internal/backup/providers/s3/s3.go
@@ -143,6 +143,7 @@ func (b *BackupProviderS3) EnsureBackupBucket(ctx context.Context) error {
 					},
 					Status: types.ExpirationStatusEnabled,
 					ID:     aws.String("backup-restore-lifecycle"),
+					Filter: &types.LifecycleRuleFilter{},
 				},
 			},
 		},

--- a/cmd/internal/backup/providers/s3/s3.go
+++ b/cmd/internal/backup/providers/s3/s3.go
@@ -157,8 +157,10 @@ func (b *BackupProviderS3) EnsureBackupBucket(ctx context.Context) error {
 			return err
 		}
 		for _, r := range bucketLifecycleConfiguration.Rules {
-			if r.ID != lifecycleRuleID {
-				rules = append(rules, r)
+			if r.ID != nil && lifecycleRuleID != nil {
+				if *r.ID != *lifecycleRuleID {
+					rules = append(rules, r)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Description

For the gcp backup provider, the lifecycle policy for object versions is based on `numNewerVersions`.
This PR replaces `NoncurrentDays` for `NewerNoncurrentVersions` for the s3 backup provider, to have the same behavior.

Moreover, it seems that the lifecycle rules all have the same ID `backup-restore-lifecycle`, effectively replacing themselves. From the specification of `PutBucketLifecycleConfiguration` it can be seen that:

> Creates a new lifecycle configuration for the bucket or replaces an existing lifecycle configuration. Keep in mind that this will overwrite an existing lifecycle configuration, so if you want to retain any configuration details, they must be included in the new lifecycle configuration.

Currently, we apply a `LifecycleRuleFilter`. From its specification it can be seen that:

## Required Actions 

```REQUIRED_ACTIONS
A bug has been fixed in the backup-restore-sidecar that occurred when the backup-restore-sidecar was configured to store multiple backups in the same bucket with different object prefixes. The sidecar now creates individual lifecycle rules for the object prefixes such that they do not overwrite each others configurations.

If you use such a configuration, it is required to clean up the old lifecycle rule that does not match an object prefix after rolling out this version of the backup-restore-sidecar.
``` 

> If the Filter element is left empty, the Lifecycle Rule applies to all objects in the bucket.

Thus, this PR removes the filer, to apply the LifecycleRule to whole bucket. This is also the behavior for gcp.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
