### PR TITLE
feat: add Valkey database support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,12 @@ test-integration: kind-cluster-create
 	kind --name backup-restore-sidecar load docker-image ghcr.io/metal-stack/backup-restore-sidecar:latest
 	KUBECONFIG=$(KUBECONFIG) go test $(GO_RUN_ARG) -tags=integration -count 1 -v -p 1 -timeout 30m ./...
 
+.PHONY: test-integration-valkey
+test-integration-valkey: kind-cluster-create
+	kind --name backup-restore-sidecar load docker-image ghcr.io/metal-stack/backup-restore-sidecar:latest
+	kind --name backup-restore-sidecar load docker-image valkey/valkey:7.2
+	KUBECONFIG=$(KUBECONFIG) go test $(GO_RUN_ARG) -tags=integration -count 1 -v -p 1 -timeout 10m -run "Test_Valkey" ./...
+
 .PHONY: proto
 proto:
 	make -C proto protoc
@@ -67,6 +73,10 @@ start-etcd:
 .PHONY: start-redis
 start-redis:
 	$(MAKE)	start	DB=redis
+
+.PHONY: start-valkey
+start-valkey:
+	$(MAKE)	start	DB=valkey
 
 .PHONY: start-localfs
 start-localfs:

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ test-integration: kind-cluster-create
 .PHONY: test-integration-valkey
 test-integration-valkey: kind-cluster-create
 	kind --name backup-restore-sidecar load docker-image ghcr.io/metal-stack/backup-restore-sidecar:latest
-	kind --name backup-restore-sidecar load docker-image valkey/valkey:7.2
+	kind --name backup-restore-sidecar load docker-image ghcr.io/valkey-io/valkey:8.1-alpine
 	KUBECONFIG=$(KUBECONFIG) go test $(GO_RUN_ARG) -tags=integration -count 1 -v -p 1 -timeout 10m -run "Test_Valkey" ./...
 
 .PHONY: proto

--- a/README.md
+++ b/README.md
@@ -8,14 +8,15 @@ Probably, it does not make sense to use this project with large databases. Howev
 
 ## Supported Databases
 
-| Database    | Image        | Status | Upgrade Support |
-| ----------- | ------------ | :----: | :-------------: |
-| postgres    | >= 12-alpine |  beta  |       ✅        |
-| rethinkdb   | >= 2.4.0     |  beta  |       ❌        |
-| ETCD        | >= 3.5       | alpha  |       ❌        |
-| redis       | >= 6.0       | alpha  |       ❌        |
-| keydb       | >= 6.0       | alpha  |       ❌        |
-| localfs     |              | alpha  |       ❌        |
+| Database  | Image        | Status | Upgrade Support |
+|-----------|--------------|:------:|:---------------:|
+| postgres  | >= 12-alpine |  beta  |        ✅        |
+| rethinkdb | >= 2.4.0     |  beta  |        ❌        |
+| ETCD      | >= 3.5       | alpha  |        ❌        |
+| redis     | >= 6.0       | alpha  |        ❌        |
+| keydb     | >= 6.0       | alpha  |        ❌        |
+| valkey    | >= 8.1       | alpha  |        ❌        |
+| localfs   |              | alpha  |        ❌        |
 
 Postgres also supports updates when using the TimescaleDB extension. Please consider the integration test for supported upgrade paths.
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -340,7 +340,7 @@ func init() {
 	rootCmd.AddCommand(startCmd, waitCmd, restoreCmd, createBackupCmd, downloadBackupCmd)
 
 	rootCmd.PersistentFlags().StringP(logLevelFlg, "", "info", "sets the application log level")
-	rootCmd.PersistentFlags().StringP(databaseFlg, "", "", "the kind of the database [postgres|rethinkdb|etcd|redis|keydb|localfs]")
+	rootCmd.PersistentFlags().StringP(databaseFlg, "", "", "the kind of the database [postgres|rethinkdb|etcd|redis|keydb|valkey|localfs]")
 	rootCmd.PersistentFlags().StringP(databaseDatadirFlg, "", "", "the directory where the database stores its data in")
 
 	err := viper.BindPFlags(rootCmd.PersistentFlags())
@@ -509,7 +509,7 @@ func initDatabase() error {
 			viper.GetString(etcdEndpoints),
 			viper.GetString(etcdName),
 		)
-	case "redis", "keydb":
+	case "redis", "keydb", "valkey":
 		var err error
 		var password string
 		if viper.IsSet(redisPasswordFlg) {

--- a/deploy/valkey-local.yaml
+++ b/deploy/valkey-local.yaml
@@ -24,7 +24,7 @@ spec:
       - command:
         - backup-restore-sidecar
         - wait
-        image: valkey/valkey:7.2
+        image: ghcr.io/valkey-io/valkey:8.1-alpine
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
@@ -64,7 +64,7 @@ spec:
         - backup-restore-sidecar
         - start
         - --log-level=debug
-        image: valkey/valkey:7.2
+        image: ghcr.io/valkey-io/valkey:8.1-alpine
         imagePullPolicy: IfNotPresent
         name: backup-restore-sidecar
         ports:

--- a/deploy/valkey-local.yaml
+++ b/deploy/valkey-local.yaml
@@ -1,0 +1,151 @@
+# THESE EXAMPLES ARE GENERATED!
+# Use them as a template for your deployment, but do not commit manual changes to these files.
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  creationTimestamp: null
+  labels:
+    app: valkey
+  name: valkey
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: valkey
+  serviceName: valkey
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: valkey
+    spec:
+      containers:
+      - command:
+        - backup-restore-sidecar
+        - wait
+        image: valkey/valkey:7.2
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command:
+            - valkey-cli
+            - ping
+          failureThreshold: 3
+          initialDelaySeconds: 15
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: valkey
+        ports:
+        - containerPort: 6379
+          name: client
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - valkey-cli
+            - ping
+          failureThreshold: 3
+          initialDelaySeconds: 15
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources: {}
+        volumeMounts:
+        - mountPath: /data
+          name: data
+        - mountPath: /usr/local/bin/backup-restore-sidecar
+          name: bin-provision
+          subPath: backup-restore-sidecar
+        - mountPath: /etc/backup-restore-sidecar
+          name: backup-restore-sidecar-config
+      - command:
+        - backup-restore-sidecar
+        - start
+        - --log-level=debug
+        image: valkey/valkey:7.2
+        imagePullPolicy: IfNotPresent
+        name: backup-restore-sidecar
+        ports:
+        - containerPort: 8000
+          name: grpc
+        resources: {}
+        volumeMounts:
+        - mountPath: /backup
+          name: backup
+        - mountPath: /data
+          name: data
+        - mountPath: /etc/backup-restore-sidecar
+          name: backup-restore-sidecar-config
+        - mountPath: /usr/local/bin/backup-restore-sidecar
+          name: bin-provision
+          subPath: backup-restore-sidecar
+      initContainers:
+      - command:
+        - cp
+        - /backup-restore-sidecar
+        - /bin-provision
+        image: ghcr.io/metal-stack/backup-restore-sidecar:latest
+        imagePullPolicy: IfNotPresent
+        name: backup-restore-sidecar-provider
+        resources: {}
+        volumeMounts:
+        - mountPath: /bin-provision
+          name: bin-provision
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: data
+      - name: backup
+        persistentVolumeClaim:
+          claimName: backup
+      - configMap:
+          name: backup-restore-sidecar-config-valkey
+        name: backup-restore-sidecar-config
+      - emptyDir: {}
+        name: bin-provision
+  updateStrategy: {}
+  volumeClaimTemplates:
+  - metadata:
+      creationTimestamp: null
+      name: data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi
+    status: {}
+  - metadata:
+      creationTimestamp: null
+      name: backup
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi
+    status: {}
+status:
+  availableReplicas: 0
+  replicas: 0
+---
+apiVersion: v1
+data:
+  config.yaml: |
+    ---
+    bind-addr: 0.0.0.0
+    db: valkey
+    db-data-directory: /data/
+    backup-provider: local
+    backup-cron-schedule: "*/1 * * * *"
+    object-prefix: valkey-test
+    redis-addr: localhost:6379
+    encryption-key: "01234567891234560123456789123456"
+    post-exec-cmds:
+    - valkey-server
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: backup-restore-sidecar-config-valkey

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/docker/docker v28.3.0+incompatible
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/lib/pq v1.10.9
+	github.com/mdelapenya/tlscert v0.2.0
 	github.com/metal-stack/metal-lib v0.23.1
 	github.com/metal-stack/v v1.0.3
 	github.com/mholt/archiver/v3 v3.5.1
@@ -125,7 +126,6 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
-	github.com/mdelapenya/tlscert v0.2.0 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/go-archive v0.1.0 // indirect
 	github.com/moby/patternmatcher v0.6.0 // indirect

--- a/integration/valkey_test.go
+++ b/integration/valkey_test.go
@@ -1,0 +1,100 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/avast/retry-go/v4"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/metal-stack/backup-restore-sidecar/pkg/generate/examples/examples"
+)
+
+func Test_Valkey_Restore(t *testing.T) {
+	restoreFlow(t, &flowSpec{
+		databaseType:     examples.Valkey,
+		sts:              examples.ValkeySts,
+		backingResources: examples.ValkeyBackingResources,
+		addTestData:      addValkeyTestData,
+		verifyTestData:   verifyValkeyTestData,
+	})
+}
+
+func Test_Valkey_RestoreLatestFromMultipleBackups(t *testing.T) {
+	restoreLatestFromMultipleBackupsFlow(t, &flowSpec{
+		databaseType:            examples.Valkey,
+		sts:                     examples.ValkeySts,
+		backingResources:        examples.ValkeyBackingResources,
+		addTestDataWithIndex:    addValkeyTestDataWithIndex,
+		verifyTestDataWithIndex: verifyValkeyTestDataWithIndex,
+	})
+}
+
+func newValkeyClient(t *testing.T, ctx context.Context) *redis.Client {
+	var cli *redis.Client
+
+	err := retry.Do(func() error {
+		cli = redis.NewClient(&redis.Options{
+			Addr: "localhost:6379",
+		})
+		return nil
+	}, retry.Context(ctx))
+	require.NoError(t, err)
+
+	return cli
+}
+
+func addValkeyTestData(t *testing.T, ctx context.Context) {
+	cli := newValkeyClient(t, ctx)
+	defer func() {
+		_ = cli.Close()
+	}()
+
+	_, err := cli.Set(ctx, "valkey-test", "I am precious data", 1*time.Hour).Result()
+	require.NoError(t, err)
+}
+
+func verifyValkeyTestData(t *testing.T, ctx context.Context) {
+	cli := newValkeyClient(t, ctx)
+	defer func() {
+		_ = cli.Close()
+	}()
+
+	resp, err := cli.Get(ctx, "valkey-test").Result()
+	require.NoError(t, err)
+	require.NotEmpty(t, resp)
+	assert.Equal(t, "I am precious data", resp)
+}
+
+func addValkeyTestDataWithIndex(t *testing.T, ctx context.Context, index int) {
+	cli := newValkeyClient(t, ctx)
+	defer func() {
+		_ = cli.Close()
+	}()
+
+	_, err := cli.Set(
+		ctx,
+		fmt.Sprintf("valkey-%d", index),
+		fmt.Sprintf("valkey-idx-%d", index),
+		1*time.Hour).
+		Result()
+	require.NoError(t, err)
+}
+
+func verifyValkeyTestDataWithIndex(t *testing.T, ctx context.Context, index int) {
+	cli := newValkeyClient(t, ctx)
+	defer func() {
+		_ = cli.Close()
+	}()
+
+	resp, err := cli.Get(ctx, fmt.Sprintf("valkey-%d", index)).Result()
+	require.NoError(t, err)
+	require.NotEmpty(t, resp)
+	assert.Equal(t, fmt.Sprintf("valkey-idx-%d", index), resp)
+}

--- a/pkg/generate/examples/dump.go
+++ b/pkg/generate/examples/dump.go
@@ -45,6 +45,11 @@ func main() {
 			backing: examples.KeyDBBackingResources,
 		},
 		{
+			db:      examples.Valkey,
+			sts:     examples.ValkeySts,
+			backing: examples.ValkeyBackingResources,
+		},
+		{
 			db:      examples.Localfs,
 			sts:     examples.LocalfsSts,
 			backing: examples.LocalfsBackingResources,

--- a/pkg/generate/examples/examples/valkey.go
+++ b/pkg/generate/examples/examples/valkey.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	Valkey               = "valkey"
-	valkeyContainerImage = "valkey/valkey:7.2"
+	valkeyContainerImage = "ghcr.io/valkey-io/valkey:8.1-alpine"
 )
 
 func ValkeySts(namespace string) *appsv1.StatefulSet {

--- a/pkg/generate/examples/examples/valkey.go
+++ b/pkg/generate/examples/examples/valkey.go
@@ -1,0 +1,249 @@
+package examples
+
+import (
+	"github.com/metal-stack/backup-restore-sidecar/pkg/constants"
+	"github.com/metal-stack/metal-lib/pkg/pointer"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	Valkey               = "valkey"
+	valkeyContainerImage = "valkey/valkey:7.2"
+)
+
+func ValkeySts(namespace string) *appsv1.StatefulSet {
+	return &appsv1.StatefulSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "StatefulSet",
+			APIVersion: appsv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "valkey",
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app": "valkey",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			ServiceName: "valkey",
+			Replicas:    pointer.Pointer(int32(1)),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "valkey",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "valkey",
+					},
+				},
+				Spec: corev1.PodSpec{
+					HostNetwork: true,
+					Containers: []corev1.Container{
+						{
+							Name:            "valkey",
+							Image:           valkeyContainerImage,
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Command:         []string{"backup-restore-sidecar", "wait"},
+							LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									Exec: &corev1.ExecAction{
+										Command: []string{"valkey-cli", "ping"},
+									},
+								},
+								InitialDelaySeconds: 15,
+								TimeoutSeconds:      1,
+								PeriodSeconds:       5,
+								SuccessThreshold:    1,
+								FailureThreshold:    3,
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									Exec: &corev1.ExecAction{
+										Command: []string{"valkey-cli", "ping"},
+									},
+								},
+								InitialDelaySeconds: 15,
+								TimeoutSeconds:      1,
+								PeriodSeconds:       5,
+								SuccessThreshold:    1,
+								FailureThreshold:    3,
+							},
+							Ports: []corev1.ContainerPort{
+								{
+									ContainerPort: 6379,
+									Name:          "client",
+									Protocol:      corev1.ProtocolTCP,
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "data",
+									MountPath: "/data",
+								},
+								{
+									Name:      "bin-provision",
+									SubPath:   "backup-restore-sidecar",
+									MountPath: "/usr/local/bin/backup-restore-sidecar",
+								},
+								{
+									Name:      "backup-restore-sidecar-config",
+									MountPath: "/etc/backup-restore-sidecar",
+								},
+							},
+						},
+						{
+							Name:            "backup-restore-sidecar",
+							Image:           valkeyContainerImage,
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Command:         []string{"backup-restore-sidecar", "start", "--log-level=debug"},
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "grpc",
+									ContainerPort: 8000,
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "backup",
+									MountPath: constants.SidecarBaseDir,
+								},
+								{
+									Name:      "data",
+									MountPath: "/data",
+								},
+								{
+									Name:      "backup-restore-sidecar-config",
+									MountPath: "/etc/backup-restore-sidecar",
+								},
+								{
+									Name:      "bin-provision",
+									SubPath:   "backup-restore-sidecar",
+									MountPath: "/usr/local/bin/backup-restore-sidecar",
+								},
+							},
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Name:            "backup-restore-sidecar-provider",
+							Image:           backupRestoreSidecarContainerImage,
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Command: []string{
+								"cp",
+								"/backup-restore-sidecar",
+								"/bin-provision",
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "bin-provision",
+									MountPath: "/bin-provision",
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "data",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: "data",
+								},
+							},
+						},
+						{
+							Name: "backup",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: "backup",
+								},
+							},
+						},
+						{
+							Name: "backup-restore-sidecar-config",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "backup-restore-sidecar-config-valkey",
+									},
+								},
+							},
+						},
+						{
+							Name: "bin-provision",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+					},
+				},
+			},
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "data",
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{
+							corev1.ReadWriteOnce,
+						},
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "backup",
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{
+							corev1.ReadWriteOnce,
+						},
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func ValkeyBackingResources(namespace string) []client.Object {
+	return []client.Object{
+		&corev1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ConfigMap",
+				APIVersion: corev1.SchemeGroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "backup-restore-sidecar-config-valkey",
+				Namespace: namespace,
+			},
+			Data: map[string]string{
+				"config.yaml": `---
+bind-addr: 0.0.0.0
+db: valkey
+db-data-directory: /data/
+backup-provider: local
+backup-cron-schedule: "*/1 * * * *"
+object-prefix: valkey-test
+redis-addr: localhost:6379
+encryption-key: "01234567891234560123456789123456"
+post-exec-cmds:
+- valkey-server
+`,
+			},
+		},
+	}
+}


### PR DESCRIPTION
Add support for Valkey database alongside Redis and KeyDB. Reuses existing Redis implementation for full compatibility.

- Add CLI support: --db valkey
- Add Kubernetes examples and integration tests
- Add Makefile targets for testing and deployment

## Description

References: #124

Adds basic Valkey support using Redis implementation (Redis-protocol compatible).

Clustered configuration will be addressed in follow-up PRs as described in #124.

<!--
If possible, please reference other issues or pull requests.

Closes #

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
