### PR TITLE
ONTAP compatibility

### DIFF
--- a/cmd/internal/backup/providers/s3/s3.go
+++ b/cmd/internal/backup/providers/s3/s3.go
@@ -254,9 +254,10 @@ func (b *BackupProviderS3) UploadBackup(ctx context.Context, reader io.Reader) e
 
 	uploader := manager.NewUploader(b.c)
 	_, err := uploader.Upload(ctx, &s3.PutObjectInput{
-		Bucket: bucket,
-		Key:    aws.String(destination),
-		Body:   reader,
+		Bucket:            bucket,
+		Key:               aws.String(destination),
+		Body:              reader,
+		ChecksumAlgorithm: types.ChecksumAlgorithmSha256,
 	})
 	if err != nil {
 		return err

--- a/cmd/internal/backup/providers/s3/s3.go
+++ b/cmd/internal/backup/providers/s3/s3.go
@@ -117,7 +117,6 @@ func New(log *slog.Logger, cfg *BackupProviderConfigS3) (*BackupProviderS3, erro
 		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(cfg.AccessKey, cfg.SecretKey, "")),
 		config.WithRegion(cfg.Region),
 		config.WithHTTPClient(httpClient),
-		config.WithClientLogMode(aws.LogRequest|aws.LogResponse),
 	)
 	if err != nil {
 		return nil, err

--- a/cmd/internal/backup/providers/s3/s3.go
+++ b/cmd/internal/backup/providers/s3/s3.go
@@ -167,6 +167,7 @@ func (b *BackupProviderS3) EnsureBackupBucket(ctx context.Context) error {
 		{
 			NoncurrentVersionExpiration: &types.NoncurrentVersionExpiration{
 				NewerNoncurrentVersions: &b.config.ObjectsToKeep,
+				NoncurrentDays:          aws.Int32(14),
 			},
 			Status: types.ExpirationStatusEnabled,
 			ID:     lifecycleRuleID,

--- a/cmd/internal/backup/providers/s3/s3.go
+++ b/cmd/internal/backup/providers/s3/s3.go
@@ -116,6 +116,7 @@ func New(log *slog.Logger, cfg *BackupProviderConfigS3) (*BackupProviderS3, erro
 		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(cfg.AccessKey, cfg.SecretKey, "")),
 		config.WithRegion(cfg.Region),
 		config.WithHTTPClient(httpClient),
+		config.WithClientLogMode(aws.LogRequest|aws.LogResponse),
 	)
 	if err != nil {
 		return nil, err

--- a/cmd/internal/backup/providers/s3/s3.go
+++ b/cmd/internal/backup/providers/s3/s3.go
@@ -167,8 +167,7 @@ func (b *BackupProviderS3) EnsureBackupBucket(ctx context.Context) error {
 	rules := []types.LifecycleRule{
 		{
 			NoncurrentVersionExpiration: &types.NoncurrentVersionExpiration{
-				NewerNoncurrentVersions: &b.config.ObjectsToKeep,
-				NoncurrentDays:          aws.Int32(14),
+				NoncurrentDays:          &b.config.ObjectsToKeep,
 			},
 			Status: types.ExpirationStatusEnabled,
 			ID:     lifecycleRuleID,

--- a/cmd/internal/backup/providers/s3/s3.go
+++ b/cmd/internal/backup/providers/s3/s3.go
@@ -248,18 +248,10 @@ func withContentMD5(u *manager.Uploader) {
 	clientOptions := make([]func(*s3.Options), 0, len(u.ClientOptions)+1)
 	clientOptions = append(clientOptions, func(o *s3.Options) {
 		o.APIOptions = append(o.APIOptions, func(stack *middleware.Stack) error {
-			if _, err := stack.Initialize.Remove("AWSChecksum:SetupInputContext"); err != nil {
-				return err
-			}
-			if _, err := stack.Build.Remove("AWSChecksum:RequestMetricsTracking"); err != nil {
-				return err
-			}
-			if _, err := stack.Finalize.Remove("AWSChecksum:ComputeInputPayloadChecksum"); err != nil {
-				return err
-			}
-			if _, err := stack.Finalize.Remove("addInputChecksumTrailer"); err != nil {
-				return err
-			}
+			_, _ = stack.Initialize.Remove("AWSChecksum:SetupInputContext")
+			_, _ = stack.Build.Remove("AWSChecksum:RequestMetricsTracking")
+			_, _ = stack.Finalize.Remove("AWSChecksum:ComputeInputPayloadChecksum")
+			_, _ = stack.Finalize.Remove("addInputChecksumTrailer")
 			return smithyhttp.AddContentChecksumMiddleware(stack)
 		})
 	})

--- a/cmd/internal/backup/providers/s3/s3.go
+++ b/cmd/internal/backup/providers/s3/s3.go
@@ -141,6 +141,8 @@ func New(log *slog.Logger, cfg *BackupProviderConfigS3) (*BackupProviderS3, erro
 func (b *BackupProviderS3) EnsureBackupBucket(ctx context.Context) error {
 	// some s3 storage implementations do not properly return the already exists or already owned by you
 	// error codes. therefore, we check if the bucket already exists in the backend by listing them first.
+	alreadyExists := false
+
 	buckets, err := b.c.ListBuckets(ctx, &s3.ListBucketsInput{})
 	if err != nil {
 		return fmt.Errorf("unable to list backup buckets: %w", err)
@@ -153,20 +155,22 @@ func (b *BackupProviderS3) EnsureBackupBucket(ctx context.Context) error {
 
 		return *bucket.Name == b.config.BucketName
 	}) {
-		return nil
+		alreadyExists = true
 	}
 
-	// create bucket
-	_, err = b.c.CreateBucket(ctx, &s3.CreateBucketInput{
-		Bucket: aws.String(b.config.BucketName),
-	})
-	if err != nil {
-		var (
-			bucketAlreadyExists     *types.BucketAlreadyExists
-			bucketAlreadyOwnerByYou *types.BucketAlreadyOwnedByYou
-		)
-		if !errors.As(err, &bucketAlreadyExists) && !errors.As(err, &bucketAlreadyOwnerByYou) {
-			return err
+	if !alreadyExists {
+		// create bucket
+		_, err = b.c.CreateBucket(ctx, &s3.CreateBucketInput{
+			Bucket: aws.String(b.config.BucketName),
+		})
+		if err != nil {
+			var (
+				bucketAlreadyExists     *types.BucketAlreadyExists
+				bucketAlreadyOwnerByYou *types.BucketAlreadyOwnedByYou
+			)
+			if !errors.As(err, &bucketAlreadyExists) && !errors.As(err, &bucketAlreadyOwnerByYou) {
+				return err
+			}
 		}
 	}
 

--- a/cmd/internal/backup/providers/s3/s3.go
+++ b/cmd/internal/backup/providers/s3/s3.go
@@ -5,9 +5,11 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
+	"slices"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -137,8 +139,25 @@ func New(log *slog.Logger, cfg *BackupProviderConfigS3) (*BackupProviderS3, erro
 
 // EnsureBackupBucket ensures a backup bucket at the backup provider
 func (b *BackupProviderS3) EnsureBackupBucket(ctx context.Context) error {
+	// some s3 storage implementations do not properly return the already exists or already owned by you
+	// error codes. therefore, we check if the bucket already exists in the backend by listing them first.
+	buckets, err := b.c.ListBuckets(ctx, &s3.ListBucketsInput{})
+	if err != nil {
+		return fmt.Errorf("unable to list backup buckets: %w", err)
+	}
+
+	if slices.ContainsFunc(buckets.Buckets, func(bucket types.Bucket) bool {
+		if bucket.Name == nil {
+			return false
+		}
+
+		return *bucket.Name == b.config.BucketName
+	}) {
+		return nil
+	}
+
 	// create bucket
-	_, err := b.c.CreateBucket(ctx, &s3.CreateBucketInput{
+	_, err = b.c.CreateBucket(ctx, &s3.CreateBucketInput{
 		Bucket: aws.String(b.config.BucketName),
 	})
 	if err != nil {
@@ -167,7 +186,7 @@ func (b *BackupProviderS3) EnsureBackupBucket(ctx context.Context) error {
 	rules := []types.LifecycleRule{
 		{
 			NoncurrentVersionExpiration: &types.NoncurrentVersionExpiration{
-				NoncurrentDays:          &b.config.ObjectsToKeep,
+				NoncurrentDays: &b.config.ObjectsToKeep,
 			},
 			Status: types.ExpirationStatusEnabled,
 			ID:     lifecycleRuleID,


### PR DESCRIPTION
## Description

ONTAP only supports at most 100 noncurrent versions (https://github.com/metal-stack/backup-restore-sidecar/issues/122) and also requires a non-positive noncurrent days.

Example of a working fifecycle configuration:
```xml
<?xml version="1.0"?>
<LifecycleConfiguration>
	<Rule>
		<ID>ipam-db-lab-backup-restore-lifecycle</ID>
		<Status>Enabled</Status>
		<Filter>
			<Prefix>ipam-db-lab/</Prefix>
		</Filter>
		<NoncurrentVersionExpiration>
			<NewerNoncurrentVersions>100</NewerNoncurrentVersions>
		        <NoncurrentDays>14</NoncurrentDays>
		</NoncurrentVersionExpiration>
	</Rule>
</LifecycleConfiguration>
```


<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
