### PR TITLE
feat: introduce restore dirty state marker, startup probes and optional database probe timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,22 @@ Be aware that, if you change the object prefix under which the backups are store
 ## Deployment
 The [deploy](deploy/) directory contains manifests as a reference for deploying the `backup-restore-sidecar`. Because configuration (like environment variables, `ConfigMap` parameters, and `post-exec-cmds`) differs heavily between database engines and storage providers, these generated manifests serve as the best reference for your specific setup. 
 
+### Manual Deployment
+
+Since the sidecar actively controls the database startup sequence, it effectively replaces a standard database deployment. To deploy your database paired with the sidecar, you typically need to apply two resources: the backup provider secret and the complete database manifest.
+
+1. **Apply the backup provider secret:**
+   Copy a secret template like `deploy/provider-secret-s3.yaml`, add your storage credentials, and apply it:
+   ```bash
+   kubectl apply -f your-provider-secret.yaml
+   ```
+
+2. **Apply the database manifest:**
+   Copy the matching template for your setup (e.g., `deploy/postgres-s3.yaml`). This contains the complete deployment (`StatefulSet`, `ConfigMap`, `Secret`, `Service`). Adapt parameters like PVC storage classes, image tags, namespaces, and credentials to your environment, then apply:
+   ```bash
+   kubectl apply -f your-database-manifest.yaml
+   ```
+
 To see the backup-restore-sidecar in the wild, you can take a look at our [metal-roles](https://github.com/metal-stack/metal-roles/blob/master/control-plane/roles/postgres-backup-restore/templates/postgres.yaml), which deploys the backup-restore-sidecar for a postgres database in production.
 
 ### Startup- and readiness probes

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ It is difficult to provide sensible default probe configurations for all databas
 * **Liveness probe:** Depending on your database and workload, you may choose to configure a liveness probe. This should not be too aggressive to avoid false positives during heavy-load operations.
 
 **Sidecar Internal Probe Timeout (`--probe-timeout`)**
-The sidecar features an internal timeout (default: `0`, meaning disabled) for probing the database connection. This acts as an optional watchdog against **silent failures**. If the database boots perfectly but the sidecar has invalid credentials or a broken connection string, it will hang infinitely. Because the backup loop hasn't started, no error metrics are emitted, however, the `backup_database_available` metric will remain `0`.
+The sidecar features an internal timeout (default: `0`, meaning disabled) for probing the database connection. This acts as an optional watchdog against **silent failures**. If the database boots perfectly but the sidecar has invalid credentials or a broken connection string, it will hang infinitely. Because the backup loop hasn't started, no error metrics are emitted, however, the `backup_database_initialized` metric will remain `0`.
 
 If you prefer Kubernetes-native `CrashLoopBackOff` alerting over metric-based alerting, you can set this timeout to force a container crash. Do not forget that this will cause the Pod to be removed from service endpoints until the database is available again, so use with caution.
 
@@ -122,7 +122,7 @@ The sidecar exposes Prometheus metrics on port `2112` at the `/metrics` endpoint
 Operators should set up Prometheus alerts based on the provided metrics:
 
 * `backup_success` (Gauge): Is `0` when the last backup failed, and `1` when it was successful. This is the primary metric for alerting.
-* `backup_database_available` (Gauge): Is `0` when the sidecar cannot connect to the database (e.g. wrong credentials, wrong port, or database not yet accepting connections), and `1` when connected. Useful for alerting on silent failures while the database probe hangs. Starts at `0` until the first successful probe.
+* `backup_database_initialized` (Gauge): Is `0` when the database is not initialized (either from a fresh start or after a restore), and `1` when it is initialized. Useful for alerting on silent failures while the database probe hangs. Starts at `0` until the first successful probe.
 * `backup_errors` (CounterVec): Total number of errors during backups, labeled by operation.
 * `backup_total_backups` (Counter): Total number of successful backups.
 * `backup_size` (Gauge): Size of the last backup in bytes.

--- a/README.md
+++ b/README.md
@@ -123,9 +123,16 @@ Operators should set up Prometheus alerts based on the provided metrics:
 
 * `backup_success` (Gauge): Is `0` when the last backup failed, and `1` when it was successful. This is the primary metric for alerting.
 * `backup_database_initialized` (Gauge): Is `0` when the database is not initialized (either from a fresh start or after a restore), and `1` when it is initialized. Useful for alerting on silent failures while the database probe hangs. Starts at `0` until the first successful probe.
-* `backup_errors` (CounterVec): Total number of errors during backups, labeled by operation.
+* `backup_errors` (CounterVec): Total number of errors during backups, labeled by `operation`. The following operation values are emitted, corresponding to the phases of a single backup cycle:
+  * `create` — database dump creation failed (e.g. `pg_dump`, `rethinkdb dump`).
+  * `delete_prior` — cleanup of the local stale backup file before creating a new one failed.
+  * `compress` — packaging the dump into a tar/tar.gz/tar.lz4 archive failed.
+  * `encrypt` — AES encryption of the archive failed (only emitted when `--encryption-key` is set).
+  * `open` — opening the local archive file for upload failed.
+  * `upload` — uploading the archive to the configured storage provider (S3/GCS/local) failed. This is the most critical operation, as errors here mean the backup never reached remote storage.
+  * `cleanup` — pruning of old backups at the storage provider (according to the retention policy) failed.
 * `backup_total_backups` (Counter): Total number of successful backups.
-* `backup_size` (Gauge): Size of the last backup in bytes.
+* `backup_size` (Gauge): Size of the last successful backup in bytes. Not reset on failure, so after a failed backup the gauge still reports the previous successful backup's size.
 
 There is no health endpoint for the sidecar, as a failed backup should not affect the availability of the database.
 The backup-restore-sidecar is designed to be resilient to backup failures, and it will continue to operate and attempt future backups even if one fails.

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 This project provides automated backup and recovery for K8s databases.
 
-**Core Design Principle**
+## Core Design Principle
 This sidecar solution actively controls the database startup sequence. Instead of acting as a passive sidecar, it intercepts the main database container until the latest backup is completely downloaded and restored.
 As soon as the restore process is finished, the sidecar signals the database container to start.
 After a successful startup, the sidecar continuously runs in the background, performing regular backups according to your defined schedule. [See the sequence diagram in the How it works section](#how-it-works).
+If the sidecar is interrupted during a restore (e.g. pod eviction or crash), it detects the incomplete state on the next startup and automatically re-downloads and re-restores the backup. This prevents the database from starting with partially restored data.
 
 The idea is taken from the [etcd-backup-restore](https://github.com/gardener/etcd-backup-restore) project.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # K8s Backup Restore Sidecar for Databases
 
-This project adds automatic backup and recovery to databases managed by K8s via sidecar.
+This project provides automated backup and recovery for K8s databases.
+
+**Core Design Principle**
+This sidecar solution actively controls the database startup sequence. Instead of acting as a passive sidecar, it intercepts the main database container until the latest backup is completely downloaded and restored.
+As soon as the restore process is finished, the sidecar signals the database container to start.
+After a successful startup, the sidecar continuously runs in the background, performing regular backups according to your defined schedule. [See the sequence diagram in the How it works section](#how-it-works)
 
 The idea is taken from the [etcd-backup-restore](https://github.com/gardener/etcd-backup-restore) project.
 
@@ -74,7 +79,32 @@ It is possible to let multiple backup-restore-sidecars (for different databases)
 
 Be aware that, if you change the object prefix under which the backups are stored, the old lifecycle policies matching this prefix are not automatically cleaned up and have to be removed manually.
 
-## Try it out
+## Deployment
+The [deploy](deploy/) directory contains manifests as a reference for deploying the `backup-restore-sidecar`. Because configuration (like environment variables, `ConfigMap` parameters, and `post-exec-cmds`) differs heavily between database engines and storage providers, these generated manifests serve as the best reference for your specific setup. 
+
+To see the backup-restore-sidecar in the wild, you can take a look at our [metal-roles](https://github.com/metal-stack/metal-roles/blob/master/control-plane/roles/postgres-backup-restore/templates/postgres.yaml), which deploys the backup-restore-sidecar for a postgres database in production.
+
+### Startup- and readiness probes
+The [manifests](deploy) have a startup probe and a readiness probe configured for the database to avoid restarts of the database during the restore process and to only serve traffic when the database is ready.
+
+* **Startup probe:** Configured with a long timeout threshold (e.g. 1h) to give the initializer enough time to restore a backup before the probe fails and the pod is restarted. This can be necessary, especially for large databases, as the restore process can take a while.
+* **Readiness probe:** Configured with a short timeout (e.g. 5s) to quickly detect when the database is ready to serve traffic (after the initial startup probe has succeeded).
+* **Liveness probe:** Not recommended for the database container. A liveness probe could incorrectly kill the database during heavy-load operations. It will not interfere with the restore process, as Kubernetes disables liveness probes until the startup probe successfully succeeds.
+
+### Monitoring and Alerting
+The sidecar exposes Prometheus metrics on port `2112` at the `/metrics` endpoint. 
+
+Operators should set up Prometheus alerts based on the provided metrics:
+
+* `backup_success` (Gauge): Is `0` when the last backup failed, and `1` when it was successful. This is the primary metric for alerting.
+* `backup_errors` (CounterVec): Total number of errors during backups, labeled by operation.
+* `backup_total_backups` (Counter): Total number of successful backups.
+* `backup_size` (Gauge): Size of the last backup in bytes.
+
+There is no health endpoint for the sidecar, as a failed backup should not affect the availability of the database.
+The backup-restore-sidecar is designed to be resilient to backup failures, and it will continue to operate and attempt future backups even if one fails.
+
+## Local Development / Demo Setup
 
 Requires:
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This project provides automated backup and recovery for K8s databases.
 **Core Design Principle**
 This sidecar solution actively controls the database startup sequence. Instead of acting as a passive sidecar, it intercepts the main database container until the latest backup is completely downloaded and restored.
 As soon as the restore process is finished, the sidecar signals the database container to start.
-After a successful startup, the sidecar continuously runs in the background, performing regular backups according to your defined schedule. [See the sequence diagram in the How it works section](#how-it-works)
+After a successful startup, the sidecar continuously runs in the background, performing regular backups according to your defined schedule. [See the sequence diagram in the How it works section](#how-it-works).
 
 The idea is taken from the [etcd-backup-restore](https://github.com/gardener/etcd-backup-restore) project.
 
@@ -80,7 +80,7 @@ It is possible to let multiple backup-restore-sidecars (for different databases)
 Be aware that, if you change the object prefix under which the backups are stored, the old lifecycle policies matching this prefix are not automatically cleaned up and have to be removed manually.
 
 ## Deployment
-The [deploy](deploy/) directory contains manifests as a reference for deploying the `backup-restore-sidecar`. Because configuration (like environment variables, `ConfigMap` parameters, and `post-exec-cmds`) differs heavily between database engines and storage providers, these generated manifests serve as the best reference for your specific setup. 
+The [deploy](deploy/) directory contains manifests as a reference for deploying the `backup-restore-sidecar`. Because configuration (like environment variables, `ConfigMap` parameters, and `post-exec-cmds`) differs heavily between database engines and storage providers, these generated manifests serve as the best reference for your specific setup.
 
 ### Manual Deployment
 
@@ -115,12 +115,12 @@ If you prefer Kubernetes-native `CrashLoopBackOff` alerting over metric-based al
 > **Note:** If you enable this timeout, it **must closely align with your database `startupProbe` threshold**. If your sidecar timeout is much shorter than the startup probe, the sidecar will prematurely crash while the database is legitimately busy recovering. This causes a noisy `CrashLoopBackOff` and unnecessarily removes the Pod from service endpoints.
 
 ### Monitoring and Alerting
-The sidecar exposes Prometheus metrics on port `2112` at the `/metrics` endpoint. 
+The sidecar exposes Prometheus metrics on port `2112` at the `/metrics` endpoint.
 
 Operators should set up Prometheus alerts based on the provided metrics:
 
 * `backup_success` (Gauge): Is `0` when the last backup failed, and `1` when it was successful. This is the primary metric for alerting.
-* `backup_database_available` (Gauge): Is `0` when the sidecar cannot connect to the database (e.g. wrong credentials, wrong port, or database not yet accepting connections), and `1` when connected. Useful for alerting on silent failures while the database probe hangs.
+* `backup_database_available` (Gauge): Is `0` when the sidecar cannot connect to the database (e.g. wrong credentials, wrong port, or database not yet accepting connections), and `1` when connected. Useful for alerting on silent failures while the database probe hangs. Starts at `0` until the first successful probe.
 * `backup_errors` (CounterVec): Total number of errors during backups, labeled by operation.
 * `backup_total_backups` (Counter): Total number of successful backups.
 * `backup_size` (Gauge): Size of the last backup in bytes.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This project provides automated backup and recovery for K8s databases.
 
 ## Core Design Principle
 This sidecar solution actively controls the database startup sequence. Instead of acting as a passive sidecar, it intercepts the main database container until the latest backup is completely downloaded and restored.
-As soon as the restore process is finished, the sidecar signals the database container to start.
+The database container is configured to actively poll the sidecar's recovery status and only proceeds with the actual database startup once the restore process has successfully finished.
 After a successful startup, the sidecar continuously runs in the background, performing regular backups according to your defined schedule. [See the sequence diagram in the How it works section](#how-it-works).
-If the sidecar is interrupted during a restore (e.g. pod eviction or crash), it detects the incomplete state on the next startup and automatically re-downloads and re-restores the backup. This prevents the database from starting with partially restored data.
+If the sidecar is interrupted during a restore (e.g. pod eviction or crash), it detects the incomplete state on the next startup and prevents the database from starting with partially restored data by halting the pod startup. In this case, manual intervention is required (see [Maintenance](#maintenance)).
 
 The idea is taken from the [etcd-backup-restore](https://github.com/gardener/etcd-backup-restore) project.
 
@@ -146,6 +146,14 @@ By default, the backup-restore-sidecar will start with the `local` backup provid
 1. Configure the backup provider secret in `deploy/provider-secret-<backup-provider>.yaml`.
 2. Run `BACKUP_PROVIDER=<backup-provider> make start-postgres` instead.
 
-## Manual restoration
+## Maintenance
+
+### Handling Failed Restores
+
+If a restore process is interrupted, the database directory might not be empty and a `.restore_in_progress` marker file is left behind. This marker purposefully prevents the pod from starting instead of automatically retrying the restoration. If this happens, manual intervention is required:
+- If the data is actually intact, you can delete the `.restore_in_progress` marker file manually.
+- Alternatively, you can clear the data directory to let it retry or perform a [manual restore](docs/manual_restore.md).
+
+### Manual Restoration
 
 Follow the documentation [here](docs/manual_restore.md) in order to manually restore a specific version of your database.

--- a/README.md
+++ b/README.md
@@ -91,12 +91,20 @@ The [manifests](deploy) have a startup probe and a readiness probe configured fo
 * **Readiness probe:** Configured with a short timeout (e.g. 5s) to quickly detect when the database is ready to serve traffic (after the initial startup probe has succeeded).
 * **Liveness probe:** Not recommended for the database container. A liveness probe could incorrectly kill the database during heavy-load operations. It will not interfere with the restore process, as Kubernetes disables liveness probes until the startup probe successfully succeeds.
 
+**Sidecar Internal Probe Timeout (`--probe-timeout`)**
+The sidecar features an internal timeout (default: `0`, meaning disabled) for probing the database connection. This acts as an optional watchdog against **silent failures**. If the database boots perfectly but the sidecar has invalid credentials or a broken connection string, it will hang infinitely. Because the backup loop hasn't started, no error metrics are emitted, however, the `backup_database_available` metric will remain `0`.
+
+If you prefer Kubernetes-native `CrashLoopBackOff` alerting over metric-based alerting, you can set this timeout to force a container crash. Do not forget that this will cause the Pod to be removed from service endpoints until the database is available again, so use with caution.
+
+> **Note:** If you enable this timeout, it **must closely align with your database `startupProbe` threshold**. If your sidecar timeout is much shorter than the startup probe, the sidecar will prematurely crash while the database is legitimately busy recovering. This causes a noisy `CrashLoopBackOff` and unnecessarily removes the Pod from service endpoints.
+
 ### Monitoring and Alerting
 The sidecar exposes Prometheus metrics on port `2112` at the `/metrics` endpoint. 
 
 Operators should set up Prometheus alerts based on the provided metrics:
 
 * `backup_success` (Gauge): Is `0` when the last backup failed, and `1` when it was successful. This is the primary metric for alerting.
+* `backup_database_available` (Gauge): Is `0` when the sidecar cannot connect to the database (e.g. wrong credentials, wrong port, or database not yet accepting connections), and `1` when connected. Useful for alerting on silent failures while the database probe hangs.
 * `backup_errors` (CounterVec): Total number of errors during backups, labeled by operation.
 * `backup_total_backups` (Counter): Total number of successful backups.
 * `backup_size` (Gauge): Size of the last backup in bytes.

--- a/README.md
+++ b/README.md
@@ -101,12 +101,13 @@ Since the sidecar actively controls the database startup sequence, it effectivel
 
 To see the backup-restore-sidecar in the wild, you can take a look at our [metal-roles](https://github.com/metal-stack/metal-roles/blob/master/control-plane/roles/postgres-backup-restore/templates/postgres.yaml), which deploys the backup-restore-sidecar for a postgres database in production.
 
-### Startup- and readiness probes
-The [manifests](deploy) have a startup probe and a readiness probe configured for the database to avoid restarts of the database during the restore process and to only serve traffic when the database is ready.
+### Startup-, Readiness-, and Liveness Probes
+The [manifests](deploy) have probes configured for the database container, to avoid restarts of the database during the restore process and to only serve traffic when the database is ready.
+It is difficult to provide sensible default probe configurations for all databases, so the provided probes are just examples and should be adapted to your specific use-case.
 
-* **Startup probe:** Configured with a long timeout threshold (e.g. 1h) to give the initializer enough time to restore a backup before the probe fails and the pod is restarted. This can be necessary, especially for large databases, as the restore process can take a while.
+* **Startup probe:** If your database takes a long time to get ready on restored data directories (e.g. because it has to replay a large WAL or has a large data directory), you should adapt the startup probe to have a longer timeout threshold. This can avoid premature restarts of the database container while it is legitimately busy recovering.
 * **Readiness probe:** Configured with a short timeout (e.g. 5s) to quickly detect when the database is ready to serve traffic (after the initial startup probe has succeeded).
-* **Liveness probe:** Not recommended for the database container. A liveness probe could incorrectly kill the database during heavy-load operations. It will not interfere with the restore process, as Kubernetes disables liveness probes until the startup probe successfully succeeds.
+* **Liveness probe:** Depending on your database and workload, you may choose to configure a liveness probe. This should not be too aggressive to avoid false positives during heavy-load operations.
 
 **Sidecar Internal Probe Timeout (`--probe-timeout`)**
 The sidecar features an internal timeout (default: `0`, meaning disabled) for probing the database connection. This acts as an optional watchdog against **silent failures**. If the database boots perfectly but the sidecar has invalid credentials or a broken connection string, it will hang infinitely. Because the backup loop hasn't started, no error metrics are emitted, however, the `backup_database_available` metric will remain `0`.

--- a/cmd/internal/database/contract.go
+++ b/cmd/internal/database/contract.go
@@ -3,9 +3,6 @@ package database
 import "context"
 
 type DatabaseInitializer interface {
-	// Check indicates whether a restore of the database is required or not.
-	Check(ctx context.Context) (bool, error)
-
 	// Recover performs a restore of the database.
 	Recover(ctx context.Context) error
 

--- a/cmd/internal/database/etcd/etcd.go
+++ b/cmd/internal/database/etcd/etcd.go
@@ -43,20 +43,6 @@ func New(log *slog.Logger, datadir, caCert, cert, key, endpoints, name string) *
 	}
 }
 
-// Check indicates whether a restore of the database is required or not.
-func (db *Etcd) Check(_ context.Context) (bool, error) {
-	empty, err := utils.IsEmpty(db.datadir)
-	if err != nil {
-		return false, err
-	}
-	if empty {
-		db.log.Info("data directory is empty")
-		return true, err
-	}
-
-	return false, nil
-}
-
 // Backup takes a full Backup of etcd with etcdctl.
 func (db *Etcd) Backup(ctx context.Context) error {
 	snapshotFileName := path.Join(constants.BackupDir, "snapshot.db")

--- a/cmd/internal/database/localfs/localfs.go
+++ b/cmd/internal/database/localfs/localfs.go
@@ -22,20 +22,6 @@ func New(log *slog.Logger, datadir string) *LocalFS {
 	}
 }
 
-// Check if Datadir is empty
-func (l *LocalFS) Check(ctx context.Context) (bool, error) {
-	empty, err := utils.IsEmpty(l.datadir)
-	if err != nil {
-		return false, err
-	}
-	if empty {
-		l.log.Info("data directory is empty")
-		return true, err
-	}
-
-	return false, nil
-}
-
 // put Datadir into constants.BackupDir directory
 func (l *LocalFS) Backup(ctx context.Context) error {
 	if err := os.RemoveAll(constants.BackupDir); err != nil {

--- a/cmd/internal/database/postgres/postgres.go
+++ b/cmd/internal/database/postgres/postgres.go
@@ -45,20 +45,6 @@ func New(log *slog.Logger, datadir string, host string, port int, user string, p
 	}
 }
 
-// Check indicates whether a restore of the database is required or not.
-func (db *Postgres) Check(_ context.Context) (bool, error) {
-	empty, err := utils.IsEmpty(db.datadir)
-	if err != nil {
-		return false, err
-	}
-	if empty {
-		db.log.Info("data directory is empty")
-		return true, err
-	}
-
-	return false, nil
-}
-
 // Backup takes a backup of the database
 func (db *Postgres) Backup(ctx context.Context) error {
 	// for new databases the postgres binaries required for Upgrade() cannot be copied before the database is running

--- a/cmd/internal/database/redis/redis.go
+++ b/cmd/internal/database/redis/redis.go
@@ -104,21 +104,6 @@ func (db *Redis) Backup(ctx context.Context) error {
 	return nil
 }
 
-// Check indicates whether a restore of the database is required or not.
-func (db *Redis) Check(_ context.Context) (bool, error) {
-	empty, err := utils.IsEmpty(db.datadir)
-	if err != nil {
-		return false, err
-	}
-
-	if empty {
-		db.log.Info("data directory is empty")
-		return true, err
-	}
-
-	return false, nil
-}
-
 // Probe figures out if the database is running and available for taking backups.
 func (db *Redis) Probe(ctx context.Context) error {
 	_, err := db.client.Ping(ctx).Result()

--- a/cmd/internal/database/rethinkdb/rethinkdb.go
+++ b/cmd/internal/database/rethinkdb/rethinkdb.go
@@ -22,7 +22,6 @@ import (
 )
 
 const (
-	connectionTimeout             = 1 * time.Second
 	restoreDatabaseStartupTimeout = 30 * time.Second
 
 	rethinkDBCmd        = "rethinkdb"
@@ -53,20 +52,6 @@ func New(log *slog.Logger, datadir string, url string, passwordFile string) *Ret
 		passwordFile: passwordFile,
 		executor:     utils.NewExecutor(log),
 	}
-}
-
-// Check indicates whether a restore of the database is required or not.
-func (db *RethinkDB) Check(_ context.Context) (bool, error) {
-	empty, err := utils.IsEmpty(db.datadir)
-	if err != nil {
-		return false, err
-	}
-	if empty {
-		db.log.Info("data directory is empty")
-		return true, err
-	}
-
-	return false, nil
 }
 
 // Backup takes a backup of the database

--- a/cmd/internal/initializer/initializer.go
+++ b/cmd/internal/initializer/initializer.go
@@ -251,24 +251,20 @@ func (i *Initializer) Restore(ctx context.Context, version *providers.BackupVers
 	}
 
 	i.currentStatus.Message = "uncompressing backup"
-	err = i.comp.Decompress(backupFilePath)
-	if err != nil {
+	if err := i.comp.Decompress(backupFilePath); err != nil {
 		return fmt.Errorf("unable to uncompress backup: %w", err)
 	}
 
-	err = utils.MarkRestoreInProgress(constants.DownloadDir)
-	if err != nil {
+	if err := utils.MarkRestoreInProgress(constants.DownloadDir, version.Version, version.Date.String()); err != nil {
 		return fmt.Errorf("unable to mark restore in progress: %w", err)
 	}
 
 	i.currentStatus.Message = "restoring backup"
-	err = i.db.Recover(ctx)
-	if err != nil {
+	if err := i.db.Recover(ctx); err != nil {
 		return fmt.Errorf("restoring database was not successful: %w", err)
 	}
 
-	err = utils.UnmarkRestoreInProgress(constants.DownloadDir)
-	if err != nil {
+	if err := utils.UnmarkRestoreInProgress(constants.DownloadDir); err != nil {
 		return fmt.Errorf("unable to unmark restore in progress: %w", err)
 	}
 

--- a/cmd/internal/initializer/initializer.go
+++ b/cmd/internal/initializer/initializer.go
@@ -17,6 +17,7 @@ import (
 	"github.com/metal-stack/backup-restore-sidecar/cmd/internal/database"
 	"github.com/metal-stack/backup-restore-sidecar/cmd/internal/encryption"
 	"github.com/metal-stack/backup-restore-sidecar/cmd/internal/metrics"
+	"github.com/metal-stack/backup-restore-sidecar/cmd/internal/utils"
 	"github.com/metal-stack/backup-restore-sidecar/pkg/constants"
 
 	"google.golang.org/grpc"
@@ -149,14 +150,23 @@ func (i *Initializer) initialize(ctx context.Context) error {
 	i.currentStatus.Status = v1.StatusResponse_CHECKING
 	i.currentStatus.Message = "checking database"
 
-	needsBackup, err := i.db.Check(ctx)
+	var dirty bool
+	empty, err := utils.IsEmpty(i.dbDataDir)
 	if err != nil {
-		return fmt.Errorf("unable to check data of database: %w", err)
+		return fmt.Errorf("unable to check if data of database empty: %w", err)
 	}
-
-	if !needsBackup {
-		i.log.Info("database does not need to be restored")
-		return nil
+	if empty {
+		i.log.Info("database data directory is empty")
+	} else {
+		dirty, err = utils.IsRestoreDirty(constants.DownloadDir)
+		if err != nil {
+			return fmt.Errorf("unable to check if restore is dirty: %w", err)
+		}
+		if !dirty {
+			i.log.Info("database does not need to be restored")
+			return nil
+		}
+		i.log.Info("data directory is not empty but restore is dirty, this means a restore process was started but not completed successfully")
 	}
 
 	i.log.Info("database potentially needs to be restored, looking for backup")
@@ -243,10 +253,20 @@ func (i *Initializer) Restore(ctx context.Context, version *providers.BackupVers
 		return fmt.Errorf("unable to uncompress backup: %w", err)
 	}
 
+	err = utils.MarkRestoreInProgress(constants.DownloadDir)
+	if err != nil {
+		return fmt.Errorf("unable to mark restore in progress: %w", err)
+	}
+
 	i.currentStatus.Message = "restoring backup"
 	err = i.db.Recover(ctx)
 	if err != nil {
 		return fmt.Errorf("restoring database was not successful: %w", err)
+	}
+
+	err = utils.UnmarkRestoreInProgress(constants.DownloadDir)
+	if err != nil {
+		return fmt.Errorf("unable to unmark restore in progress: %w", err)
 	}
 
 	return nil

--- a/cmd/internal/initializer/initializer.go
+++ b/cmd/internal/initializer/initializer.go
@@ -166,6 +166,9 @@ func (i *Initializer) initialize(ctx context.Context) error {
 			i.log.Info("database does not need to be restored")
 			return nil
 		}
+
+		// The .restore_in_progress marker prevents the pod from starting instead of automatically retrying a restore.
+		// If this happens, manual intervention is required (e.g., deleting the marker file if the data is alright, or performing a manual restore).
 		return fmt.Errorf("preceding restore was not completed successfully: data directory is not empty but .restore_in_progress file exists")
 	}
 

--- a/cmd/internal/initializer/initializer.go
+++ b/cmd/internal/initializer/initializer.go
@@ -265,7 +265,7 @@ func (i *Initializer) Restore(ctx context.Context, version *providers.BackupVers
 	}
 
 	if err := utils.UnmarkRestoreInProgress(constants.DownloadDir); err != nil {
-		return fmt.Errorf("unable to unmark restore in progress: %w", err)
+		return fmt.Errorf("unable to remove restore in progress marker: %w", err)
 	}
 
 	return nil

--- a/cmd/internal/initializer/initializer.go
+++ b/cmd/internal/initializer/initializer.go
@@ -166,7 +166,7 @@ func (i *Initializer) initialize(ctx context.Context) error {
 			i.log.Info("database does not need to be restored")
 			return nil
 		}
-		i.log.Info("data directory is not empty but restore is dirty, this means a restore process was started but not completed successfully")
+		i.log.Warn("data directory is not empty but restore is dirty, this means a restore process was started but not completed successfully")
 	}
 
 	i.log.Info("database potentially needs to be restored, looking for backup")

--- a/cmd/internal/initializer/initializer.go
+++ b/cmd/internal/initializer/initializer.go
@@ -166,7 +166,7 @@ func (i *Initializer) initialize(ctx context.Context) error {
 			i.log.Info("database does not need to be restored")
 			return nil
 		}
-		i.log.Warn("data directory is not empty but restore is dirty, this means a restore process was started but not completed successfully")
+		return fmt.Errorf("preceding restore was not completed successfully: data directory is not empty but .restore_in_progress file exists")
 	}
 
 	i.log.Info("database potentially needs to be restored, looking for backup")

--- a/cmd/internal/metrics/metrics.go
+++ b/cmd/internal/metrics/metrics.go
@@ -12,11 +12,11 @@ import (
 
 // Metrics contains the collected metrics
 type Metrics struct {
-	totalBackups      prometheus.Counter
-	backupSuccess     prometheus.Gauge
-	databaseAvailable prometheus.Gauge
-	backupSize        prometheus.Gauge
-	totalErrors       *prometheus.CounterVec
+	totalBackups        prometheus.Counter
+	backupSuccess       prometheus.Gauge
+	databaseInitialized prometheus.Gauge
+	backupSize          prometheus.Gauge
+	totalErrors         *prometheus.CounterVec
 }
 
 // New generates new metrics
@@ -27,9 +27,9 @@ func New() *Metrics {
 	},
 	)
 
-	databaseAvailable := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "backup_database_available",
-		Help: "is 1 when the database is available for backups, 0 otherwise",
+	databaseInitialized := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "backup_database_initialized",
+		Help: "is 1 when the database is initialized for backups and a database probe has succeeded once, 0 otherwise",
 	},
 	)
 
@@ -53,11 +53,11 @@ func New() *Metrics {
 	)
 
 	return &Metrics{
-		totalBackups:      totalBackups,
-		backupSuccess:     backupSuccess,
-		databaseAvailable: databaseAvailable,
-		totalErrors:       totalErrors,
-		backupSize:        backupSize,
+		totalBackups:        totalBackups,
+		backupSuccess:       backupSuccess,
+		databaseInitialized: databaseInitialized,
+		totalErrors:         totalErrors,
+		backupSize:          backupSize,
 	}
 }
 
@@ -77,7 +77,7 @@ func (m *Metrics) Start(log *slog.Logger) {
 	})
 
 	prometheus.MustRegister(m.backupSuccess)
-	prometheus.MustRegister(m.databaseAvailable)
+	prometheus.MustRegister(m.databaseInitialized)
 	prometheus.MustRegister(m.totalBackups)
 	prometheus.MustRegister(m.totalErrors)
 	prometheus.MustRegister(m.backupSize)
@@ -108,11 +108,11 @@ func (m *Metrics) CountError(op string) {
 	m.backupSuccess.Set(0)
 }
 
-// SetDatabaseAvailable updates the database available metric
-func (m *Metrics) SetDatabaseAvailable(available bool) {
-	if available {
-		m.databaseAvailable.Set(1)
+// SetDatabaseInitialized updates the database initialized metric
+func (m *Metrics) SetDatabaseInitialized(initialized bool) {
+	if initialized {
+		m.databaseInitialized.Set(1)
 	} else {
-		m.databaseAvailable.Set(0)
+		m.databaseInitialized.Set(0)
 	}
 }

--- a/cmd/internal/metrics/metrics.go
+++ b/cmd/internal/metrics/metrics.go
@@ -22,7 +22,7 @@ type Metrics struct {
 func New() *Metrics {
 	backupSuccess := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "backup_success",
-		Help: "is 0 when the last backup was successful, otherwise 1",
+		Help: "is 1 when the last backup was successful, otherwise 0",
 	},
 	)
 

--- a/cmd/internal/metrics/metrics.go
+++ b/cmd/internal/metrics/metrics.go
@@ -12,10 +12,11 @@ import (
 
 // Metrics contains the collected metrics
 type Metrics struct {
-	totalBackups  prometheus.Counter
-	backupSuccess prometheus.Gauge
-	backupSize    prometheus.Gauge
-	totalErrors   *prometheus.CounterVec
+	totalBackups      prometheus.Counter
+	backupSuccess     prometheus.Gauge
+	databaseAvailable prometheus.Gauge
+	backupSize        prometheus.Gauge
+	totalErrors       *prometheus.CounterVec
 }
 
 // New generates new metrics
@@ -23,6 +24,12 @@ func New() *Metrics {
 	backupSuccess := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "backup_success",
 		Help: "is 1 when the last backup was successful, otherwise 0",
+	},
+	)
+
+	databaseAvailable := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "backup_database_available",
+		Help: "is 1 when the database is available for backups, 0 otherwise",
 	},
 	)
 
@@ -46,10 +53,11 @@ func New() *Metrics {
 	)
 
 	return &Metrics{
-		totalBackups:  totalBackups,
-		backupSuccess: backupSuccess,
-		totalErrors:   totalErrors,
-		backupSize:    backupSize,
+		totalBackups:      totalBackups,
+		backupSuccess:     backupSuccess,
+		databaseAvailable: databaseAvailable,
+		totalErrors:       totalErrors,
+		backupSize:        backupSize,
 	}
 }
 
@@ -69,6 +77,7 @@ func (m *Metrics) Start(log *slog.Logger) {
 	})
 
 	prometheus.MustRegister(m.backupSuccess)
+	prometheus.MustRegister(m.databaseAvailable)
 	prometheus.MustRegister(m.totalBackups)
 	prometheus.MustRegister(m.totalErrors)
 	prometheus.MustRegister(m.backupSize)
@@ -97,4 +106,13 @@ func (m *Metrics) CountBackup(backupFile string) {
 func (m *Metrics) CountError(op string) {
 	m.totalErrors.With(prometheus.Labels{"operation": op}).Inc()
 	m.backupSuccess.Set(0)
+}
+
+// SetDatabaseAvailable updates the database available metric
+func (m *Metrics) SetDatabaseAvailable(available bool) {
+	if available {
+		m.databaseAvailable.Set(1)
+	} else {
+		m.databaseAvailable.Set(0)
+	}
 }

--- a/cmd/internal/probe/probe.go
+++ b/cmd/internal/probe/probe.go
@@ -11,22 +11,41 @@ import (
 
 var (
 	probeInterval = 3 * time.Second
+	probeTimeout  = 10 * time.Second
 )
 
 // Start starts the database prober
 func Start(ctx context.Context, log *slog.Logger, db database.DatabaseProber) error {
 	log.Info("start probing database")
 
+	probeTicker := time.NewTicker(probeInterval)
+	defer probeTicker.Stop()
+
+	var lastErrMsg string
+	var lastLogTime time.Time
+
 	for {
 		select {
 		case <-ctx.Done():
-			return errors.New("received stop signal, stop probing")
-		case <-time.After(probeInterval):
-			err := db.Probe(ctx)
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return errors.New("timeout reached while probing database")
+			}
+			return errors.New("received stop signal, shutting down")
+		case <-probeTicker.C:
+			probeCtx, cancelProbe := context.WithTimeout(ctx, probeTimeout)
+			err := db.Probe(probeCtx)
+			cancelProbe()
+
 			if err == nil {
 				return nil
 			}
-			log.Error("database has not yet started, waiting and retrying...", "error", err)
+
+			errMsg := err.Error()
+			if errMsg != lastErrMsg || time.Since(lastLogTime) > 1*time.Minute {
+				log.Info("database has not yet started, waiting and retrying...", "error", err)
+				lastErrMsg = errMsg
+				lastLogTime = time.Now()
+			}
 		}
 	}
 }

--- a/cmd/internal/probe/probe.go
+++ b/cmd/internal/probe/probe.go
@@ -9,9 +9,9 @@ import (
 	"github.com/metal-stack/backup-restore-sidecar/cmd/internal/database"
 )
 
-var (
-	probeInterval = 3 * time.Second
-	probeTimeout  = 10 * time.Second
+const (
+	probeInterval    = 3 * time.Second
+	probeCallTimeout = 10 * time.Second
 )
 
 // Start starts the database prober
@@ -32,7 +32,7 @@ func Start(ctx context.Context, log *slog.Logger, db database.DatabaseProber) er
 			}
 			return errors.New("received stop signal, shutting down")
 		case <-probeTicker.C:
-			probeCtx, cancelProbe := context.WithTimeout(ctx, probeTimeout)
+			probeCtx, cancelProbe := context.WithTimeout(ctx, probeCallTimeout)
 			err := db.Probe(probeCtx)
 			cancelProbe()
 
@@ -42,7 +42,7 @@ func Start(ctx context.Context, log *slog.Logger, db database.DatabaseProber) er
 
 			errMsg := err.Error()
 			if errMsg != lastErrMsg || time.Since(lastLogTime) > 1*time.Minute {
-				log.Info("database has not yet started, waiting and retrying...", "error", err)
+				log.Warn("database has not yet started, waiting and retrying...", "error", err)
 				lastErrMsg = errMsg
 				lastLogTime = time.Now()
 			}

--- a/cmd/internal/utils/files.go
+++ b/cmd/internal/utils/files.go
@@ -44,17 +44,13 @@ func IsRestoreDirty(dir string) (bool, error) {
 
 // MarkRestoreInProgress creates a file named `.restore_in_progress` in the provided directory
 // to indicate that a restore process is currently in progress.
-// If the file already exists, it does nothing.
+// If the file already exists, it returns an error.
 // If there is an error while creating the file, it returns an error.
 func MarkRestoreInProgress(dir string, version string, date string) error {
 	restoreMarkerPath := filepath.Join(dir, ".restore_in_progress")
 
 	f, err := os.OpenFile(restoreMarkerPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
 	if err != nil {
-		if errors.Is(err, os.ErrExist) {
-			// file already exists
-			return nil
-		}
 		return fmt.Errorf("unable to create restore marker file: %w", err)
 	}
 	defer func() {
@@ -71,13 +67,13 @@ func MarkRestoreInProgress(dir string, version string, date string) error {
 
 // UnmarkRestoreInProgress removes the `.restore_in_progress` file from the provided directory
 // to indicate that a restore process has completed.
-// If the file does not exist, it does nothing.
+// If the file does not exist, it returns an error.
 // If there is an error while removing the file, it returns an error.
 func UnmarkRestoreInProgress(dir string) error {
 	restoreMarkerPath := filepath.Join(dir, ".restore_in_progress")
 	if err := os.Remove(restoreMarkerPath); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return nil
+			return fmt.Errorf("restore marker file does not exist: %w", err)
 		}
 		return fmt.Errorf("unable to remove restore marker file: %w", err)
 	}

--- a/cmd/internal/utils/files.go
+++ b/cmd/internal/utils/files.go
@@ -57,10 +57,11 @@ func MarkRestoreInProgress(dir string, version string, date string) error {
 		}
 		return fmt.Errorf("unable to create restore marker file: %w", err)
 	}
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 
-	// write version and date to the marker file for better debugging
-	_, err = f.WriteString(fmt.Sprintf("version: %s\ndate: %s\n", version, date))
+	_, err = fmt.Fprintf(f, "version: %s\ndate: %s\n", version, date)
 	if err != nil {
 		return fmt.Errorf("unable to write version info to restore marker file: %w", err)
 	}

--- a/cmd/internal/utils/files.go
+++ b/cmd/internal/utils/files.go
@@ -46,24 +46,24 @@ func IsRestoreDirty(dir string) (bool, error) {
 // to indicate that a restore process is currently in progress.
 // If the file already exists, it does nothing.
 // If there is an error while creating the file, it returns an error.
-func MarkRestoreInProgress(dir string) error {
+func MarkRestoreInProgress(dir string, version string, date string) error {
 	restoreMarkerPath := filepath.Join(dir, ".restore_in_progress")
-	_, err := os.Stat(restoreMarkerPath)
-	if err == nil {
-		// file already exists
-		return nil
-	}
-	if !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("unable to check for restore marker file: %w", err)
-	}
 
-	f, err := os.Create(restoreMarkerPath)
+	f, err := os.OpenFile(restoreMarkerPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
 	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			// file already exists
+			return nil
+		}
 		return fmt.Errorf("unable to create restore marker file: %w", err)
 	}
-	defer func() {
-		_ = f.Close()
-	}()
+	defer f.Close()
+
+	// write version and date to the marker file for better debugging
+	_, err = f.WriteString(fmt.Sprintf("version: %s\ndate: %s\n", version, date))
+	if err != nil {
+		return fmt.Errorf("unable to write version info to restore marker file: %w", err)
+	}
 
 	return nil
 }

--- a/cmd/internal/utils/files.go
+++ b/cmd/internal/utils/files.go
@@ -28,6 +28,62 @@ func IsEmpty(name string) (bool, error) {
 	return false, err
 }
 
+// IsRestoreDirty checks whether the `.restore_in_progress` file exists in the provided directory,
+// which indicates that a restore process was started but not yet completed successfully.
+func IsRestoreDirty(dir string) (bool, error) {
+	restoreMarkerPath := filepath.Join(dir, ".restore_in_progress")
+	_, err := os.Stat(restoreMarkerPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// MarkRestoreInProgress creates a file named `.restore_in_progress` in the provided directory
+// to indicate that a restore process is currently in progress.
+// If the file already exists, it does nothing.
+// If there is an error while creating the file, it returns an error.
+func MarkRestoreInProgress(dir string) error {
+	restoreMarkerPath := filepath.Join(dir, ".restore_in_progress")
+	_, err := os.Stat(restoreMarkerPath)
+	if err == nil {
+		// file already exists
+		return nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("unable to check for restore marker file: %w", err)
+	}
+
+	f, err := os.Create(restoreMarkerPath)
+	if err != nil {
+		return fmt.Errorf("unable to create restore marker file: %w", err)
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	return nil
+}
+
+// UnmarkRestoreInProgress removes the `.restore_in_progress` file from the provided directory
+// to indicate that a restore process has completed.
+// If the file does not exist, it does nothing.
+// If there is an error while removing the file, it returns an error.
+func UnmarkRestoreInProgress(dir string) error {
+	restoreMarkerPath := filepath.Join(dir, ".restore_in_progress")
+	if err := os.Remove(restoreMarkerPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("unable to remove restore marker file: %w", err)
+	}
+
+	return nil
+}
+
 // RemoveContents removes all files from a directory, but not the directory itself
 func RemoveContents(dir string) error {
 	d, err := os.Open(dir)

--- a/cmd/internal/wait/wait.go
+++ b/cmd/internal/wait/wait.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	waitInterval = 3 * time.Second
-	grcpTimeout  = 10 * time.Second
+	grpcTimeout  = 10 * time.Second
 )
 
 // Start starts a wait component that will return when the initializer server has done its job
@@ -36,7 +36,7 @@ func Start(ctx context.Context, log *slog.Logger, addr string) error {
 			log.Info("received stop signal, shutting down")
 			return nil
 		case <-waitTicker.C:
-			grpcCtx, cancel := context.WithTimeout(ctx, grcpTimeout)
+			grpcCtx, cancel := context.WithTimeout(ctx, grpcTimeout)
 			resp, err := client.InitializerServiceClient().Status(grpcCtx, &v1.StatusRequest{})
 			cancel()
 

--- a/cmd/internal/wait/wait.go
+++ b/cmd/internal/wait/wait.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	waitInterval = 3 * time.Second
+	grcpTimeout  = 10 * time.Second
 )
 
 // Start starts a wait component that will return when the initializer server has done its job
@@ -22,13 +23,23 @@ func Start(ctx context.Context, log *slog.Logger, addr string) error {
 
 	log.Info("waiting until initializer completes", "interval", waitInterval.String())
 
+	waitTicker := time.NewTicker(waitInterval)
+	defer waitTicker.Stop()
+
+	var lastStatus v1.StatusResponse_InitializerStatus
+	var lastMessage string
+	var lastLogTime time.Time
+
 	for {
 		select {
 		case <-ctx.Done():
 			log.Info("received stop signal, shutting down")
 			return nil
-		case <-time.After(waitInterval):
-			resp, err := client.InitializerServiceClient().Status(ctx, &v1.StatusRequest{})
+		case <-waitTicker.C:
+			grpcCtx, cancel := context.WithTimeout(ctx, grcpTimeout)
+			resp, err := client.InitializerServiceClient().Status(grpcCtx, &v1.StatusRequest{})
+			cancel()
+
 			if err != nil {
 				log.Error("error retrieving initializer server response", "error", err)
 				continue
@@ -38,8 +49,12 @@ func Start(ctx context.Context, log *slog.Logger, addr string) error {
 				log.Info("initializer succeeded, database can be started", "message", resp.GetMessage())
 				return nil
 			}
-
-			log.Info("initializer has not yet succeeded", "status", resp.GetStatus(), "message", resp.GetMessage())
+			if resp.GetStatus() != lastStatus || resp.GetMessage() != lastMessage || time.Since(lastLogTime) > 1*time.Minute {
+				log.Info("initializer has not yet succeeded", "status", resp.GetStatus(), "message", resp.GetMessage())
+				lastStatus = resp.GetStatus()
+				lastMessage = resp.GetMessage()
+				lastLogTime = time.Now()
+			}
 		}
 	}
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -190,7 +190,7 @@ var startCmd = &cobra.Command{
 			probeCtx, probeCancel = context.WithTimeout(stop, timeout)
 		}
 
-		metrics.SetDatabaseAvailable(false)
+		metrics.SetDatabaseInitialized(false)
 		err := probe.Start(probeCtx, logger.WithGroup("probe"), db)
 		if probeCancel != nil {
 			probeCancel()
@@ -198,7 +198,7 @@ var startCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		metrics.SetDatabaseAvailable(true)
+		metrics.SetDatabaseInitialized(true)
 
 		return backuper.Start(stop)
 	},

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -99,7 +99,7 @@ const (
 
 	downloadOutputFlg = "output"
 
-	probeTimeout = "probe-timeout"
+	probeTimeoutFlg = "probe-timeout"
 )
 
 var (
@@ -186,7 +186,7 @@ var startCmd = &cobra.Command{
 
 		probeCtx := stop
 		var probeCancel context.CancelFunc
-		if timeout := viper.GetDuration(probeTimeout); timeout > 0 {
+		if timeout := viper.GetDuration(probeTimeoutFlg); timeout > 0 {
 			probeCtx, probeCancel = context.WithTimeout(stop, timeout)
 		}
 
@@ -411,7 +411,7 @@ func init() {
 
 	startCmd.Flags().StringP(encryptionKeyFlg, "", "", "the encryption key for aes")
 
-	startCmd.Flags().Duration(probeTimeout, 0, "the duration to wait for the database to be available after a restore until giving up (e.g. 30s, 5m, 1h). Set to 0 to disable. It is highly recommended to align this with the Kubernetes StartupProbe threshold if you choose to enable it.")
+	startCmd.Flags().Duration(probeTimeoutFlg, 0, "the duration to wait for the database to be available after a restore until giving up (e.g. 30s, 5m, 1h). Set to 0 to disable. It is highly recommended to align this with the Kubernetes StartupProbe threshold if you choose to enable it.")
 
 	err = viper.BindPFlags(startCmd.Flags())
 	if err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -98,6 +98,8 @@ const (
 	encryptionKeyFlg = "encryption-key"
 
 	downloadOutputFlg = "output"
+
+	probeTimeout = "probe-timeout"
 )
 
 var (
@@ -168,13 +170,35 @@ var startCmd = &cobra.Command{
 			Encrypter:      encrypter,
 		})
 
-		if err := initializer.New(logger.WithGroup("initializer"), addr, db, bp, compressor, metrics, viper.GetString(databaseDatadirFlg), encrypter).Start(stop, backuper); err != nil {
+		initializer := initializer.New(
+			logger.WithGroup("initializer"),
+			addr,
+			db,
+			bp,
+			compressor,
+			metrics,
+			viper.GetString(databaseDatadirFlg),
+			encrypter)
+
+		if err := initializer.Start(stop, backuper); err != nil {
 			return err
 		}
 
-		if err := probe.Start(stop, logger.WithGroup("probe"), db); err != nil {
+		probeCtx := stop
+		var probeCancel context.CancelFunc
+		if timeout := viper.GetDuration(probeTimeout); timeout > 0 {
+			probeCtx, probeCancel = context.WithTimeout(stop, timeout)
+		}
+
+		metrics.SetDatabaseAvailable(false)
+		err := probe.Start(probeCtx, logger.WithGroup("probe"), db)
+		if probeCancel != nil {
+			probeCancel()
+		}
+		if err != nil {
 			return err
 		}
+		metrics.SetDatabaseAvailable(true)
 
 		return backuper.Start(stop)
 	},
@@ -386,6 +410,8 @@ func init() {
 	startCmd.Flags().StringP(compressionMethod, "", "targz", "the compression method to use to compress the backups (tar|targz|tarlz4)")
 
 	startCmd.Flags().StringP(encryptionKeyFlg, "", "", "the encryption key for aes")
+
+	startCmd.Flags().Duration(probeTimeout, 0, "the duration to wait for the database to be available after a restore until giving up (e.g. 30s, 5m, 1h). Set to 0 to disable. It is highly recommended to align this with the Kubernetes StartupProbe threshold if you choose to enable it.")
 
 	err = viper.BindPFlags(startCmd.Flags())
 	if err != nil {

--- a/deploy/etcd-local.yaml
+++ b/deploy/etcd-local.yaml
@@ -33,7 +33,6 @@ spec:
             - health
             - --endpoints=127.0.0.1:32379
           failureThreshold: 3
-          initialDelaySeconds: 15
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
@@ -51,7 +50,6 @@ spec:
             path: /health
             port: 32381
             scheme: HTTP
-          initialDelaySeconds: 15
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
@@ -63,8 +61,7 @@ spec:
             - endpoint
             - health
             - --endpoints=127.0.0.1:32379
-          failureThreshold: 360
-          initialDelaySeconds: 15
+          failureThreshold: 60
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1

--- a/deploy/etcd-local.yaml
+++ b/deploy/etcd-local.yaml
@@ -25,6 +25,18 @@ spec:
         - backup-restore-sidecar
         - wait
         image: quay.io/coreos/etcd:v3.5.21
+        livenessProbe:
+          exec:
+            command:
+            - /usr/local/bin/etcdctl
+            - endpoint
+            - health
+            - --endpoints=127.0.0.1:32379
+          failureThreshold: 3
+          initialDelaySeconds: 15
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
         name: etcd
         ports:
         - containerPort: 32379

--- a/deploy/etcd-local.yaml
+++ b/deploy/etcd-local.yaml
@@ -25,18 +25,6 @@ spec:
         - backup-restore-sidecar
         - wait
         image: quay.io/coreos/etcd:v3.5.21
-        livenessProbe:
-          exec:
-            command:
-            - /usr/local/bin/etcdctl
-            - endpoint
-            - health
-            - --endpoints=127.0.0.1:32379
-          failureThreshold: 3
-          initialDelaySeconds: 15
-          periodSeconds: 5
-          successThreshold: 1
-          timeoutSeconds: 1
         name: etcd
         ports:
         - containerPort: 32379
@@ -56,6 +44,18 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources: {}
+        startupProbe:
+          exec:
+            command:
+            - /usr/local/bin/etcdctl
+            - endpoint
+            - health
+            - --endpoints=127.0.0.1:32379
+          failureThreshold: 360
+          initialDelaySeconds: 15
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
         volumeMounts:
         - mountPath: /data
           name: data

--- a/deploy/keydb-local.yaml
+++ b/deploy/keydb-local.yaml
@@ -25,6 +25,16 @@ spec:
         - backup-restore-sidecar
         - wait
         image: eqalpha/keydb:alpine
+        livenessProbe:
+          exec:
+            command:
+            - keydb-cli
+            - ping
+          failureThreshold: 3
+          initialDelaySeconds: 15
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
         name: keydb
         ports:
         - containerPort: 6379

--- a/deploy/keydb-local.yaml
+++ b/deploy/keydb-local.yaml
@@ -31,7 +31,6 @@ spec:
             - keydb-cli
             - ping
           failureThreshold: 3
-          initialDelaySeconds: 15
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
@@ -46,7 +45,6 @@ spec:
             - keydb-cli
             - ping
           failureThreshold: 3
-          initialDelaySeconds: 15
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
@@ -56,8 +54,7 @@ spec:
             command:
             - keydb-cli
             - ping
-          failureThreshold: 360
-          initialDelaySeconds: 15
+          failureThreshold: 60
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1

--- a/deploy/keydb-local.yaml
+++ b/deploy/keydb-local.yaml
@@ -25,16 +25,6 @@ spec:
         - backup-restore-sidecar
         - wait
         image: eqalpha/keydb:alpine
-        livenessProbe:
-          exec:
-            command:
-            - keydb-cli
-            - ping
-          failureThreshold: 3
-          initialDelaySeconds: 15
-          periodSeconds: 5
-          successThreshold: 1
-          timeoutSeconds: 1
         name: keydb
         ports:
         - containerPort: 6379
@@ -51,6 +41,16 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources: {}
+        startupProbe:
+          exec:
+            command:
+            - keydb-cli
+            - ping
+          failureThreshold: 360
+          initialDelaySeconds: 15
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
         volumeMounts:
         - mountPath: /data
           name: data

--- a/deploy/postgres-local.yaml
+++ b/deploy/postgres-local.yaml
@@ -60,7 +60,6 @@ spec:
             - -p
             - "5432"
           failureThreshold: 6
-          initialDelaySeconds: 30
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 5
@@ -81,7 +80,6 @@ spec:
             - -p
             - "5432"
           failureThreshold: 3
-          initialDelaySeconds: 5
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 5
@@ -99,8 +97,7 @@ spec:
             - 127.0.0.1
             - -p
             - "5432"
-          failureThreshold: 360
-          initialDelaySeconds: 5
+          failureThreshold: 30
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 5

--- a/deploy/postgres-local.yaml
+++ b/deploy/postgres-local.yaml
@@ -46,6 +46,24 @@ spec:
               key: POSTGRES_DATA
               name: postgres
         image: postgres:16-alpine
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - exec
+            - pg_isready
+            - -U
+            - postgres
+            - -h
+            - 127.0.0.1
+            - -p
+            - "5432"
+          failureThreshold: 6
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
         name: postgres
         ports:
         - containerPort: 5432

--- a/deploy/postgres-local.yaml
+++ b/deploy/postgres-local.yaml
@@ -46,24 +46,6 @@ spec:
               key: POSTGRES_DATA
               name: postgres
         image: postgres:16-alpine
-        livenessProbe:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - exec
-            - pg_isready
-            - -U
-            - postgres
-            - -h
-            - 127.0.0.1
-            - -p
-            - "5432"
-          failureThreshold: 6
-          initialDelaySeconds: 30
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 5
         name: postgres
         ports:
         - containerPort: 5432
@@ -80,10 +62,30 @@ spec:
             - 127.0.0.1
             - -p
             - "5432"
+          failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 10
+          successThreshold: 1
           timeoutSeconds: 5
         resources: {}
+        startupProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - exec
+            - pg_isready
+            - -U
+            - postgres
+            - -h
+            - 127.0.0.1
+            - -p
+            - "5432"
+          failureThreshold: 360
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
         volumeMounts:
         - mountPath: /data
           name: data

--- a/deploy/redis-local.yaml
+++ b/deploy/redis-local.yaml
@@ -31,7 +31,6 @@ spec:
             - redis-cli
             - ping
           failureThreshold: 3
-          initialDelaySeconds: 15
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
@@ -46,7 +45,6 @@ spec:
             - redis-cli
             - ping
           failureThreshold: 3
-          initialDelaySeconds: 15
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
@@ -56,8 +54,7 @@ spec:
             command:
             - redis-cli
             - ping
-          failureThreshold: 360
-          initialDelaySeconds: 15
+          failureThreshold: 60
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1

--- a/deploy/redis-local.yaml
+++ b/deploy/redis-local.yaml
@@ -25,6 +25,16 @@ spec:
         - backup-restore-sidecar
         - wait
         image: redis:latest
+        livenessProbe:
+          exec:
+            command:
+            - redis-cli
+            - ping
+          failureThreshold: 3
+          initialDelaySeconds: 15
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
         name: redis
         ports:
         - containerPort: 6379

--- a/deploy/redis-local.yaml
+++ b/deploy/redis-local.yaml
@@ -25,16 +25,6 @@ spec:
         - backup-restore-sidecar
         - wait
         image: redis:latest
-        livenessProbe:
-          exec:
-            command:
-            - redis-cli
-            - ping
-          failureThreshold: 3
-          initialDelaySeconds: 15
-          periodSeconds: 5
-          successThreshold: 1
-          timeoutSeconds: 1
         name: redis
         ports:
         - containerPort: 6379
@@ -51,6 +41,16 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources: {}
+        startupProbe:
+          exec:
+            command:
+            - redis-cli
+            - ping
+          failureThreshold: 360
+          initialDelaySeconds: 15
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
         volumeMounts:
         - mountPath: /data
           name: data

--- a/deploy/rethinkdb-local.yaml
+++ b/deploy/rethinkdb-local.yaml
@@ -35,25 +35,7 @@ spec:
         ports:
         - containerPort: 8080
         - containerPort: 28015
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /
-            port: 8080
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 5
         resources: {}
-        startupProbe:
-          failureThreshold: 360
-          httpGet:
-            path: /
-            port: 8080
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 5
         volumeMounts:
         - mountPath: /data
           name: data

--- a/deploy/rethinkdb-local.yaml
+++ b/deploy/rethinkdb-local.yaml
@@ -35,7 +35,25 @@ spec:
         ports:
         - containerPort: 8080
         - containerPort: 28015
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
         resources: {}
+        startupProbe:
+          failureThreshold: 360
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
         volumeMounts:
         - mountPath: /data
           name: data

--- a/deploy/valkey-local.yaml
+++ b/deploy/valkey-local.yaml
@@ -26,6 +26,16 @@ spec:
         - wait
         image: ghcr.io/valkey-io/valkey:8.1-alpine
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command:
+            - valkey-cli
+            - ping
+          failureThreshold: 3
+          initialDelaySeconds: 15
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
         name: valkey
         ports:
         - containerPort: 6379

--- a/deploy/valkey-local.yaml
+++ b/deploy/valkey-local.yaml
@@ -26,16 +26,6 @@ spec:
         - wait
         image: ghcr.io/valkey-io/valkey:8.1-alpine
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          exec:
-            command:
-            - valkey-cli
-            - ping
-          failureThreshold: 3
-          initialDelaySeconds: 15
-          periodSeconds: 5
-          successThreshold: 1
-          timeoutSeconds: 1
         name: valkey
         ports:
         - containerPort: 6379
@@ -52,6 +42,16 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources: {}
+        startupProbe:
+          exec:
+            command:
+            - valkey-cli
+            - ping
+          failureThreshold: 360
+          initialDelaySeconds: 15
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
         volumeMounts:
         - mountPath: /data
           name: data

--- a/deploy/valkey-local.yaml
+++ b/deploy/valkey-local.yaml
@@ -32,7 +32,6 @@ spec:
             - valkey-cli
             - ping
           failureThreshold: 3
-          initialDelaySeconds: 15
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
@@ -47,7 +46,6 @@ spec:
             - valkey-cli
             - ping
           failureThreshold: 3
-          initialDelaySeconds: 15
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
@@ -57,8 +55,7 @@ spec:
             command:
             - valkey-cli
             - ping
-          failureThreshold: 360
-          initialDelaySeconds: 15
+          failureThreshold: 60
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -39,6 +39,7 @@ type flowSpec struct {
 	addTestDataWithIndex    func(t *testing.T, ctx context.Context, index int)
 	verifyTestData          func(t *testing.T, ctx context.Context)
 	verifyTestDataWithIndex func(t *testing.T, ctx context.Context, index int)
+	dataDir                 string
 }
 
 type upgradeFlowSpec struct {
@@ -177,6 +178,151 @@ func restoreFlow(t *testing.T, spec *flowSpec) {
 	t.Log("verify that data gets restored")
 
 	spec.verifyTestData(t, ctx)
+}
+
+func restoreInterruptedFlow(t *testing.T, spec *flowSpec) {
+	t.Log("running interrupted/corrupt restore flow")
+
+	require.NotEmpty(t, spec.dataDir, "dataDir must be specified for restoreInterruptedFlow")
+	var (
+		ctx, cancel = context.WithTimeout(t.Context(), 20*time.Minute)
+		ns          = testNamespace(t)
+	)
+
+	defer cancel()
+
+	cleanup := func() {
+		t.Log("running cleanup")
+
+		err := c.Delete(ctx, ns)
+		require.NoError(t, client.IgnoreNotFound(err), "cleanup did not succeed")
+
+		err = waitUntilNotFound(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ns.Name,
+			},
+		})
+		require.NoError(t, err, "cleanup did not succeed")
+	}
+	cleanup()
+	defer cleanup()
+
+	err := c.Create(ctx, ns)
+	require.NoError(t, client.IgnoreAlreadyExists(err))
+
+	t.Log("applying resource manifests")
+
+	objects := func() []client.Object {
+		objects := []client.Object{spec.sts(ns.Name)}
+		objects = append(objects, spec.backingResources(ns.Name)...)
+		return objects
+	}
+
+	for _, o := range objects() {
+		o := o
+		err = c.Create(ctx, o)
+		require.NoError(t, err)
+	}
+
+	podName := spec.sts(ns.Name).Name + "-0"
+
+	err = waitForPodRunning(ctx, podName, ns.Name)
+	require.NoError(t, err)
+
+	t.Log("adding test data to database")
+
+	spec.addTestData(t, ctx)
+
+	t.Log("taking a backup")
+
+	brsc, err := brsclient.New(ctx, "http://localhost:8000")
+	require.NoError(t, err)
+
+	_, err = brsc.DatabaseServiceClient().CreateBackup(ctx, &v1.CreateBackupRequest{})
+	if err != nil && !errors.Is(err, constants.ErrBackupAlreadyInProgress) {
+		require.NoError(t, err)
+	}
+
+	var backup *v1.Backup
+	err = retry.Do(func() error {
+		backups, err := brsc.BackupServiceClient().ListBackups(ctx, &v1.ListBackupsRequest{})
+		if err != nil {
+			return err
+		}
+
+		if len(backups.GetBackups()) == 0 {
+			return fmt.Errorf("no backups were made yet")
+		}
+
+		backup = backups.GetBackups()[0]
+
+		return nil
+	}, retry.Context(ctx), retry.Attempts(0), retry.MaxDelay(2*time.Second))
+	require.NoError(t, err)
+	require.NotNil(t, backup)
+
+	require.True(t, strings.HasSuffix(backup.GetName(), ".aes"))
+
+	t.Log("creating .restore_in_progress file to simulate interrupted restore")
+	_, err = execCommand(ctx, podName, ns.Name, "backup-restore-sidecar", []string{"mkdir", "-p", constants.DownloadDir})
+	require.NoError(t, err)
+	_, err = execCommand(ctx, podName, ns.Name, "backup-restore-sidecar", []string{"touch", constants.DownloadDir + "/.restore_in_progress"})
+	require.NoError(t, err)
+
+	t.Log("corrupting database data directory to verify re-restore actually recovers the data")
+	_, err = execCommand(ctx, podName, ns.Name, "backup-restore-sidecar",
+		[]string{"sh", "-c", "rm -rf " + spec.dataDir + "/* " + spec.dataDir + "/.[!.]* 2>/dev/null; echo dirty > " + spec.dataDir + "/corrupted"})
+	require.NoError(t, err)
+
+	t.Log("remembering pod UID to detect restart")
+	oldPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: ns.Name,
+		},
+	}
+	err = c.Get(ctx, client.ObjectKeyFromObject(oldPod), oldPod)
+	require.NoError(t, err)
+	oldUID := oldPod.UID
+
+	t.Log("restarting pod to trigger dirty restore detection")
+	err = c.Delete(ctx, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: ns.Name,
+		},
+	})
+	require.NoError(t, err)
+
+	t.Log("waiting for pod to be recreated by statefulset controller")
+	err = retry.Do(func() error {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      podName,
+				Namespace: ns.Name,
+			},
+		}
+		err := c.Get(ctx, client.ObjectKeyFromObject(pod), pod)
+		if err != nil {
+			return err
+		}
+		if pod.UID == oldUID {
+			return fmt.Errorf("pod has not been recreated yet")
+		}
+		return nil
+	}, retry.Context(ctx), retry.Attempts(0), retry.MaxDelay(2*time.Second))
+	require.NoError(t, err)
+
+	err = waitForPodRunning(ctx, podName, ns.Name)
+	require.NoError(t, err)
+
+	t.Log("verify that data got restored after the interrupted restore")
+
+	spec.verifyTestData(t, ctx)
+
+	t.Log("verify that .restore_in_progress file was removed after successful restore to avoid re-triggering restore on next startup")
+	_, err = execCommand(ctx, podName, ns.Name, "backup-restore-sidecar", []string{"ls", constants.DownloadDir + "/.restore_in_progress"})
+	require.Error(t, err)
 }
 
 func restoreLatestFromMultipleBackupsFlow(t *testing.T, spec *flowSpec) {

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -39,7 +39,6 @@ type flowSpec struct {
 	addTestDataWithIndex    func(t *testing.T, ctx context.Context, index int)
 	verifyTestData          func(t *testing.T, ctx context.Context)
 	verifyTestDataWithIndex func(t *testing.T, ctx context.Context, index int)
-	dataDir                 string
 }
 
 type upgradeFlowSpec struct {
@@ -181,9 +180,8 @@ func restoreFlow(t *testing.T, spec *flowSpec) {
 }
 
 func restoreInterruptedFlow(t *testing.T, spec *flowSpec) {
-	t.Log("running interrupted/corrupt restore flow")
+	t.Log("running interrupted restore flow")
 
-	require.NotEmpty(t, spec.dataDir, "dataDir must be specified for restoreInterruptedFlow")
 	var (
 		ctx, cancel = context.WithTimeout(t.Context(), 20*time.Minute)
 		ns          = testNamespace(t)
@@ -269,11 +267,6 @@ func restoreInterruptedFlow(t *testing.T, spec *flowSpec) {
 	_, err = execCommand(ctx, podName, ns.Name, "backup-restore-sidecar", []string{"touch", constants.DownloadDir + "/.restore_in_progress"})
 	require.NoError(t, err)
 
-	t.Log("corrupting database data directory to verify re-restore actually recovers the data")
-	_, err = execCommand(ctx, podName, ns.Name, "backup-restore-sidecar",
-		[]string{"sh", "-c", "rm -rf " + spec.dataDir + "/* " + spec.dataDir + "/.[!.]* 2>/dev/null; echo dirty > " + spec.dataDir + "/corrupted"})
-	require.NoError(t, err)
-
 	t.Log("remembering pod UID to detect restart")
 	oldPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -294,7 +287,7 @@ func restoreInterruptedFlow(t *testing.T, spec *flowSpec) {
 	})
 	require.NoError(t, err)
 
-	t.Log("waiting for pod to be recreated by statefulset controller")
+	t.Log("waiting for pod to be recreated and sidecar to fail due to dirty restore")
 	err = retry.Do(func() error {
 		pod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -309,20 +302,23 @@ func restoreInterruptedFlow(t *testing.T, spec *flowSpec) {
 		if pod.UID == oldUID {
 			return fmt.Errorf("pod has not been recreated yet")
 		}
-		return nil
+
+		for _, status := range pod.Status.ContainerStatuses {
+			if status.Name != "backup-restore-sidecar" {
+				continue
+			}
+			if status.State.Waiting != nil && (status.State.Waiting.Reason == "CrashLoopBackOff" || status.State.Waiting.Reason == "Error") {
+				return nil
+			}
+			if status.State.Terminated != nil && status.State.Terminated.ExitCode != 0 {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("sidecar container has not failed yet")
 	}, retry.Context(ctx), retry.Attempts(0), retry.MaxDelay(2*time.Second))
 	require.NoError(t, err)
 
-	err = waitForPodRunning(ctx, podName, ns.Name)
-	require.NoError(t, err)
-
-	t.Log("verify that data got restored after the interrupted restore")
-
-	spec.verifyTestData(t, ctx)
-
-	t.Log("verify that .restore_in_progress file was removed after successful restore to avoid re-triggering restore on next startup")
-	_, err = execCommand(ctx, podName, ns.Name, "backup-restore-sidecar", []string{"ls", constants.DownloadDir + "/.restore_in_progress"})
-	require.Error(t, err)
 }
 
 func restoreLatestFromMultipleBackupsFlow(t *testing.T, spec *flowSpec) {

--- a/integration/postgres_test.go
+++ b/integration/postgres_test.go
@@ -27,6 +27,17 @@ func Test_Postgres_Restore(t *testing.T) {
 	})
 }
 
+func Test_Postgres_RestoreInterrupted(t *testing.T) {
+	restoreInterruptedFlow(t, &flowSpec{
+		databaseType:     examples.Postgres,
+		sts:              examples.PostgresSts,
+		backingResources: examples.PostgresBackingResources,
+		addTestData:      addPostgresTestData,
+		verifyTestData:   verifyPostgresTestData,
+		dataDir:          "/data/postgres",
+	})
+}
+
 func Test_Postgres_RestoreLatestFromMultipleBackups(t *testing.T) {
 	restoreLatestFromMultipleBackupsFlow(t, &flowSpec{
 		databaseType:            examples.Postgres,

--- a/integration/postgres_test.go
+++ b/integration/postgres_test.go
@@ -34,7 +34,6 @@ func Test_Postgres_RestoreInterrupted(t *testing.T) {
 		backingResources: examples.PostgresBackingResources,
 		addTestData:      addPostgresTestData,
 		verifyTestData:   verifyPostgresTestData,
-		dataDir:          "/data/postgres",
 	})
 }
 

--- a/pkg/generate/examples/examples/etcd.go
+++ b/pkg/generate/examples/examples/etcd.go
@@ -74,8 +74,18 @@ func EtcdSts(namespace string) *appsv1.StatefulSet {
 								PeriodSeconds:       5,
 								SuccessThreshold:    1,
 								FailureThreshold:    3,
-							},
-							Ports: []corev1.ContainerPort{
+							}, LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									Exec: &corev1.ExecAction{
+										Command: []string{"/usr/local/bin/etcdctl", "endpoint", "health", "--endpoints=127.0.0.1:32379"},
+									},
+								},
+								InitialDelaySeconds: 15,
+								TimeoutSeconds:      1,
+								PeriodSeconds:       5,
+								SuccessThreshold:    1,
+								FailureThreshold:    3,
+							}, Ports: []corev1.ContainerPort{
 								// default ports are taken by kind etcd because running in host network
 								{
 									ContainerPort: 32379,

--- a/pkg/generate/examples/examples/etcd.go
+++ b/pkg/generate/examples/examples/etcd.go
@@ -49,7 +49,7 @@ func EtcdSts(namespace string) *appsv1.StatefulSet {
 							Name:    "etcd",
 							Image:   etcdContainerImage,
 							Command: []string{"backup-restore-sidecar", "wait"},
-							LivenessProbe: &corev1.Probe{
+							StartupProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									Exec: &corev1.ExecAction{
 										Command: []string{"/usr/local/bin/etcdctl", "endpoint", "health", "--endpoints=127.0.0.1:32379"},
@@ -59,7 +59,7 @@ func EtcdSts(namespace string) *appsv1.StatefulSet {
 								TimeoutSeconds:      1,
 								PeriodSeconds:       5,
 								SuccessThreshold:    1,
-								FailureThreshold:    3,
+								FailureThreshold:    360,
 							},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{

--- a/pkg/generate/examples/examples/etcd.go
+++ b/pkg/generate/examples/examples/etcd.go
@@ -59,7 +59,7 @@ func EtcdSts(namespace string) *appsv1.StatefulSet {
 								TimeoutSeconds:      1,
 								PeriodSeconds:       5,
 								SuccessThreshold:    1,
-								FailureThreshold:    360,
+								FailureThreshold:    360, // allow up to 30 minutes for restore and boot (360 * 5s)
 							},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{

--- a/pkg/generate/examples/examples/etcd.go
+++ b/pkg/generate/examples/examples/etcd.go
@@ -55,11 +55,11 @@ func EtcdSts(namespace string) *appsv1.StatefulSet {
 										Command: []string{"/usr/local/bin/etcdctl", "endpoint", "health", "--endpoints=127.0.0.1:32379"},
 									},
 								},
-								InitialDelaySeconds: 15,
-								TimeoutSeconds:      1,
-								PeriodSeconds:       5,
-								SuccessThreshold:    1,
-								FailureThreshold:    360, // allow up to 30 minutes for restore and boot (360 * 5s)
+
+								TimeoutSeconds:   1,
+								PeriodSeconds:    5,
+								SuccessThreshold: 1,
+								FailureThreshold: 60, // allow up to 5 minutes for restore and boot (60 * 5s)
 							},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
@@ -69,22 +69,20 @@ func EtcdSts(namespace string) *appsv1.StatefulSet {
 										Scheme: corev1.URISchemeHTTP,
 									},
 								},
-								InitialDelaySeconds: 15,
-								TimeoutSeconds:      1,
-								PeriodSeconds:       5,
-								SuccessThreshold:    1,
-								FailureThreshold:    3,
+								TimeoutSeconds:   1,
+								PeriodSeconds:    5,
+								SuccessThreshold: 1,
+								FailureThreshold: 3,
 							}, LivenessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									Exec: &corev1.ExecAction{
 										Command: []string{"/usr/local/bin/etcdctl", "endpoint", "health", "--endpoints=127.0.0.1:32379"},
 									},
 								},
-								InitialDelaySeconds: 15,
-								TimeoutSeconds:      1,
-								PeriodSeconds:       5,
-								SuccessThreshold:    1,
-								FailureThreshold:    3,
+								TimeoutSeconds:   1,
+								PeriodSeconds:    5,
+								SuccessThreshold: 1,
+								FailureThreshold: 3,
 							}, Ports: []corev1.ContainerPort{
 								// default ports are taken by kind etcd because running in host network
 								{

--- a/pkg/generate/examples/examples/keydb.go
+++ b/pkg/generate/examples/examples/keydb.go
@@ -54,11 +54,11 @@ func KeyDBSts(namespace string) *appsv1.StatefulSet {
 										Command: []string{"keydb-cli", "ping"},
 									},
 								},
-								InitialDelaySeconds: 15,
-								TimeoutSeconds:      1,
-								PeriodSeconds:       5,
-								SuccessThreshold:    1,
-								FailureThreshold:    360, // allow up to 30 minutes for restore and boot (360 * 5s)
+
+								TimeoutSeconds:   1,
+								PeriodSeconds:    5,
+								SuccessThreshold: 1,
+								FailureThreshold: 60, // allow up to 5 minutes for restore and boot (60 * 5s)
 							},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
@@ -66,22 +66,20 @@ func KeyDBSts(namespace string) *appsv1.StatefulSet {
 										Command: []string{"keydb-cli", "ping"},
 									},
 								},
-								InitialDelaySeconds: 15,
-								TimeoutSeconds:      1,
-								PeriodSeconds:       5,
-								SuccessThreshold:    1,
-								FailureThreshold:    3,
+								TimeoutSeconds:   1,
+								PeriodSeconds:    5,
+								SuccessThreshold: 1,
+								FailureThreshold: 3,
 							}, LivenessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									Exec: &corev1.ExecAction{
 										Command: []string{"keydb-cli", "ping"},
 									},
 								},
-								InitialDelaySeconds: 15,
-								TimeoutSeconds:      1,
-								PeriodSeconds:       5,
-								SuccessThreshold:    1,
-								FailureThreshold:    3,
+								TimeoutSeconds:   1,
+								PeriodSeconds:    5,
+								SuccessThreshold: 1,
+								FailureThreshold: 3,
 							}, Ports: []corev1.ContainerPort{
 								// default ports are taken by kind keydb because running in host network
 								{

--- a/pkg/generate/examples/examples/keydb.go
+++ b/pkg/generate/examples/examples/keydb.go
@@ -58,7 +58,7 @@ func KeyDBSts(namespace string) *appsv1.StatefulSet {
 								TimeoutSeconds:      1,
 								PeriodSeconds:       5,
 								SuccessThreshold:    1,
-								FailureThreshold:    360,
+								FailureThreshold:    360, // allow up to 30 minutes for restore and boot (360 * 5s)
 							},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{

--- a/pkg/generate/examples/examples/keydb.go
+++ b/pkg/generate/examples/examples/keydb.go
@@ -71,8 +71,18 @@ func KeyDBSts(namespace string) *appsv1.StatefulSet {
 								PeriodSeconds:       5,
 								SuccessThreshold:    1,
 								FailureThreshold:    3,
-							},
-							Ports: []corev1.ContainerPort{
+							}, LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									Exec: &corev1.ExecAction{
+										Command: []string{"keydb-cli", "ping"},
+									},
+								},
+								InitialDelaySeconds: 15,
+								TimeoutSeconds:      1,
+								PeriodSeconds:       5,
+								SuccessThreshold:    1,
+								FailureThreshold:    3,
+							}, Ports: []corev1.ContainerPort{
 								// default ports are taken by kind keydb because running in host network
 								{
 									ContainerPort: 6379,

--- a/pkg/generate/examples/examples/keydb.go
+++ b/pkg/generate/examples/examples/keydb.go
@@ -48,7 +48,7 @@ func KeyDBSts(namespace string) *appsv1.StatefulSet {
 							Name:    "keydb",
 							Image:   keyDBContainerImage,
 							Command: []string{"backup-restore-sidecar", "wait"},
-							LivenessProbe: &corev1.Probe{
+							StartupProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									Exec: &corev1.ExecAction{
 										Command: []string{"keydb-cli", "ping"},
@@ -58,7 +58,7 @@ func KeyDBSts(namespace string) *appsv1.StatefulSet {
 								TimeoutSeconds:      1,
 								PeriodSeconds:       5,
 								SuccessThreshold:    1,
-								FailureThreshold:    3,
+								FailureThreshold:    360,
 							},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{

--- a/pkg/generate/examples/examples/postgres.go
+++ b/pkg/generate/examples/examples/postgres.go
@@ -54,17 +54,17 @@ func PostgresSts(namespace string) *appsv1.StatefulSet {
 							Name:    "postgres",
 							Image:   postgresContainerImage,
 							Command: []string{"backup-restore-sidecar", "wait"},
-							LivenessProbe: &corev1.Probe{
+							StartupProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									Exec: &corev1.ExecAction{
 										Command: []string{"/bin/sh", "-c", "exec", "pg_isready", "-U", PostgresUser, "-h", "127.0.0.1", "-p", "5432"},
 									},
 								},
-								InitialDelaySeconds: 30,
+								InitialDelaySeconds: 5,
 								TimeoutSeconds:      5,
 								PeriodSeconds:       10,
 								SuccessThreshold:    1,
-								FailureThreshold:    6,
+								FailureThreshold:    360, // allow up to 1 hour for restore and boot (360 * 10s)
 							},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
@@ -75,6 +75,8 @@ func PostgresSts(namespace string) *appsv1.StatefulSet {
 								InitialDelaySeconds: 5,
 								TimeoutSeconds:      5,
 								PeriodSeconds:       10,
+								SuccessThreshold:    1,
+								FailureThreshold:    3,
 							},
 							Env: []corev1.EnvVar{
 								{

--- a/pkg/generate/examples/examples/postgres.go
+++ b/pkg/generate/examples/examples/postgres.go
@@ -77,8 +77,18 @@ func PostgresSts(namespace string) *appsv1.StatefulSet {
 								PeriodSeconds:       10,
 								SuccessThreshold:    1,
 								FailureThreshold:    3,
-							},
-							Env: []corev1.EnvVar{
+							}, LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									Exec: &corev1.ExecAction{
+										Command: []string{"/bin/sh", "-c", "exec", "pg_isready", "-U", PostgresUser, "-h", "127.0.0.1", "-p", "5432"},
+									},
+								},
+								InitialDelaySeconds: 30,
+								TimeoutSeconds:      5,
+								PeriodSeconds:       10,
+								SuccessThreshold:    1,
+								FailureThreshold:    6,
+							}, Env: []corev1.EnvVar{
 								{
 									Name: "POSTGRES_DB",
 									ValueFrom: &corev1.EnvVarSource{

--- a/pkg/generate/examples/examples/postgres.go
+++ b/pkg/generate/examples/examples/postgres.go
@@ -60,11 +60,11 @@ func PostgresSts(namespace string) *appsv1.StatefulSet {
 										Command: []string{"/bin/sh", "-c", "exec", "pg_isready", "-U", PostgresUser, "-h", "127.0.0.1", "-p", "5432"},
 									},
 								},
-								InitialDelaySeconds: 5,
-								TimeoutSeconds:      5,
-								PeriodSeconds:       10,
-								SuccessThreshold:    1,
-								FailureThreshold:    360, // allow up to 1 hour for restore and boot (360 * 10s)
+
+								TimeoutSeconds:   5,
+								PeriodSeconds:    10,
+								SuccessThreshold: 1,
+								FailureThreshold: 30, // allow up to 5 minutes for restore and boot (30 * 10s)
 							},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
@@ -72,22 +72,20 @@ func PostgresSts(namespace string) *appsv1.StatefulSet {
 										Command: []string{"/bin/sh", "-c", "exec", "pg_isready", "-U", PostgresUser, "-h", "127.0.0.1", "-p", "5432"},
 									},
 								},
-								InitialDelaySeconds: 5,
-								TimeoutSeconds:      5,
-								PeriodSeconds:       10,
-								SuccessThreshold:    1,
-								FailureThreshold:    3,
+								TimeoutSeconds:   5,
+								PeriodSeconds:    10,
+								SuccessThreshold: 1,
+								FailureThreshold: 3,
 							}, LivenessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									Exec: &corev1.ExecAction{
 										Command: []string{"/bin/sh", "-c", "exec", "pg_isready", "-U", PostgresUser, "-h", "127.0.0.1", "-p", "5432"},
 									},
 								},
-								InitialDelaySeconds: 30,
-								TimeoutSeconds:      5,
-								PeriodSeconds:       10,
-								SuccessThreshold:    1,
-								FailureThreshold:    6,
+								TimeoutSeconds:   5,
+								PeriodSeconds:    10,
+								SuccessThreshold: 1,
+								FailureThreshold: 6,
 							}, Env: []corev1.EnvVar{
 								{
 									Name: "POSTGRES_DB",

--- a/pkg/generate/examples/examples/redis.go
+++ b/pkg/generate/examples/examples/redis.go
@@ -58,7 +58,7 @@ func RedisSts(namespace string) *appsv1.StatefulSet {
 								TimeoutSeconds:      1,
 								PeriodSeconds:       5,
 								SuccessThreshold:    1,
-								FailureThreshold:    360,
+								FailureThreshold:    360, // allow up to 30 minutes for restore and boot (360 * 5s)
 							},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{

--- a/pkg/generate/examples/examples/redis.go
+++ b/pkg/generate/examples/examples/redis.go
@@ -71,8 +71,18 @@ func RedisSts(namespace string) *appsv1.StatefulSet {
 								PeriodSeconds:       5,
 								SuccessThreshold:    1,
 								FailureThreshold:    3,
-							},
-							Ports: []corev1.ContainerPort{
+							}, LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									Exec: &corev1.ExecAction{
+										Command: []string{"redis-cli", "ping"},
+									},
+								},
+								InitialDelaySeconds: 15,
+								TimeoutSeconds:      1,
+								PeriodSeconds:       5,
+								SuccessThreshold:    1,
+								FailureThreshold:    3,
+							}, Ports: []corev1.ContainerPort{
 								// default ports are taken by kind redis because running in host network
 								{
 									ContainerPort: 6379,

--- a/pkg/generate/examples/examples/redis.go
+++ b/pkg/generate/examples/examples/redis.go
@@ -48,7 +48,7 @@ func RedisSts(namespace string) *appsv1.StatefulSet {
 							Name:    "redis",
 							Image:   redisContainerImage,
 							Command: []string{"backup-restore-sidecar", "wait"},
-							LivenessProbe: &corev1.Probe{
+							StartupProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									Exec: &corev1.ExecAction{
 										Command: []string{"redis-cli", "ping"},
@@ -58,7 +58,7 @@ func RedisSts(namespace string) *appsv1.StatefulSet {
 								TimeoutSeconds:      1,
 								PeriodSeconds:       5,
 								SuccessThreshold:    1,
-								FailureThreshold:    3,
+								FailureThreshold:    360,
 							},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{

--- a/pkg/generate/examples/examples/redis.go
+++ b/pkg/generate/examples/examples/redis.go
@@ -54,11 +54,11 @@ func RedisSts(namespace string) *appsv1.StatefulSet {
 										Command: []string{"redis-cli", "ping"},
 									},
 								},
-								InitialDelaySeconds: 15,
-								TimeoutSeconds:      1,
-								PeriodSeconds:       5,
-								SuccessThreshold:    1,
-								FailureThreshold:    360, // allow up to 30 minutes for restore and boot (360 * 5s)
+
+								TimeoutSeconds:   1,
+								PeriodSeconds:    5,
+								SuccessThreshold: 1,
+								FailureThreshold: 60, // allow up to 5 minutes for restore and boot (60 * 5s)
 							},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
@@ -66,22 +66,20 @@ func RedisSts(namespace string) *appsv1.StatefulSet {
 										Command: []string{"redis-cli", "ping"},
 									},
 								},
-								InitialDelaySeconds: 15,
-								TimeoutSeconds:      1,
-								PeriodSeconds:       5,
-								SuccessThreshold:    1,
-								FailureThreshold:    3,
+								TimeoutSeconds:   1,
+								PeriodSeconds:    5,
+								SuccessThreshold: 1,
+								FailureThreshold: 3,
 							}, LivenessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									Exec: &corev1.ExecAction{
 										Command: []string{"redis-cli", "ping"},
 									},
 								},
-								InitialDelaySeconds: 15,
-								TimeoutSeconds:      1,
-								PeriodSeconds:       5,
-								SuccessThreshold:    1,
-								FailureThreshold:    3,
+								TimeoutSeconds:   1,
+								PeriodSeconds:    5,
+								SuccessThreshold: 1,
+								FailureThreshold: 3,
 							}, Ports: []corev1.ContainerPort{
 								// default ports are taken by kind redis because running in host network
 								{

--- a/pkg/generate/examples/examples/rethinkdb.go
+++ b/pkg/generate/examples/examples/rethinkdb.go
@@ -65,6 +65,32 @@ func RethinkDbSts(namespace string) *appsv1.StatefulSet {
 									},
 								},
 							},
+							StartupProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/",
+										Port: intstr.FromInt32(8080),
+									},
+								},
+								InitialDelaySeconds: 5,
+								TimeoutSeconds:      5,
+								PeriodSeconds:       10,
+								SuccessThreshold:    1,
+								FailureThreshold:    360,
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/",
+										Port: intstr.FromInt32(8080),
+									},
+								},
+								InitialDelaySeconds: 5,
+								TimeoutSeconds:      5,
+								PeriodSeconds:       10,
+								SuccessThreshold:    1,
+								FailureThreshold:    3,
+							},
 							Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: 8080,

--- a/pkg/generate/examples/examples/rethinkdb.go
+++ b/pkg/generate/examples/examples/rethinkdb.go
@@ -65,32 +65,6 @@ func RethinkDbSts(namespace string) *appsv1.StatefulSet {
 									},
 								},
 							},
-							StartupProbe: &corev1.Probe{
-								ProbeHandler: corev1.ProbeHandler{
-									HTTPGet: &corev1.HTTPGetAction{
-										Path: "/",
-										Port: intstr.FromInt32(8080),
-									},
-								},
-								InitialDelaySeconds: 5,
-								TimeoutSeconds:      5,
-								PeriodSeconds:       10,
-								SuccessThreshold:    1,
-								FailureThreshold:    360, // allow up to 1 hour for restore and boot (360 * 10s)
-							},
-							ReadinessProbe: &corev1.Probe{
-								ProbeHandler: corev1.ProbeHandler{
-									HTTPGet: &corev1.HTTPGetAction{
-										Path: "/",
-										Port: intstr.FromInt32(8080),
-									},
-								},
-								InitialDelaySeconds: 5,
-								TimeoutSeconds:      5,
-								PeriodSeconds:       10,
-								SuccessThreshold:    1,
-								FailureThreshold:    3,
-							},
 							Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: 8080,

--- a/pkg/generate/examples/examples/rethinkdb.go
+++ b/pkg/generate/examples/examples/rethinkdb.go
@@ -76,7 +76,7 @@ func RethinkDbSts(namespace string) *appsv1.StatefulSet {
 								TimeoutSeconds:      5,
 								PeriodSeconds:       10,
 								SuccessThreshold:    1,
-								FailureThreshold:    360,
+								FailureThreshold:    360, // allow up to 1 hour for restore and boot (360 * 10s)
 							},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{

--- a/pkg/generate/examples/examples/valkey.go
+++ b/pkg/generate/examples/examples/valkey.go
@@ -72,8 +72,18 @@ func ValkeySts(namespace string) *appsv1.StatefulSet {
 								PeriodSeconds:       5,
 								SuccessThreshold:    1,
 								FailureThreshold:    3,
-							},
-							Ports: []corev1.ContainerPort{
+							}, LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									Exec: &corev1.ExecAction{
+										Command: []string{"valkey-cli", "ping"},
+									},
+								},
+								InitialDelaySeconds: 15,
+								TimeoutSeconds:      1,
+								PeriodSeconds:       5,
+								SuccessThreshold:    1,
+								FailureThreshold:    3,
+							}, Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: 6379,
 									Name:          "client",

--- a/pkg/generate/examples/examples/valkey.go
+++ b/pkg/generate/examples/examples/valkey.go
@@ -59,7 +59,7 @@ func ValkeySts(namespace string) *appsv1.StatefulSet {
 								TimeoutSeconds:      1,
 								PeriodSeconds:       5,
 								SuccessThreshold:    1,
-								FailureThreshold:    360,
+								FailureThreshold:    360, // allow up to 30 minutes for restore and boot (360 * 5s)
 							},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{

--- a/pkg/generate/examples/examples/valkey.go
+++ b/pkg/generate/examples/examples/valkey.go
@@ -55,11 +55,11 @@ func ValkeySts(namespace string) *appsv1.StatefulSet {
 										Command: []string{"valkey-cli", "ping"},
 									},
 								},
-								InitialDelaySeconds: 15,
-								TimeoutSeconds:      1,
-								PeriodSeconds:       5,
-								SuccessThreshold:    1,
-								FailureThreshold:    360, // allow up to 30 minutes for restore and boot (360 * 5s)
+
+								TimeoutSeconds:   1,
+								PeriodSeconds:    5,
+								SuccessThreshold: 1,
+								FailureThreshold: 60, // allow up to 5 minutes for restore and boot (60 * 5s)
 							},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
@@ -67,22 +67,20 @@ func ValkeySts(namespace string) *appsv1.StatefulSet {
 										Command: []string{"valkey-cli", "ping"},
 									},
 								},
-								InitialDelaySeconds: 15,
-								TimeoutSeconds:      1,
-								PeriodSeconds:       5,
-								SuccessThreshold:    1,
-								FailureThreshold:    3,
+								TimeoutSeconds:   1,
+								PeriodSeconds:    5,
+								SuccessThreshold: 1,
+								FailureThreshold: 3,
 							}, LivenessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									Exec: &corev1.ExecAction{
 										Command: []string{"valkey-cli", "ping"},
 									},
 								},
-								InitialDelaySeconds: 15,
-								TimeoutSeconds:      1,
-								PeriodSeconds:       5,
-								SuccessThreshold:    1,
-								FailureThreshold:    3,
+								TimeoutSeconds:   1,
+								PeriodSeconds:    5,
+								SuccessThreshold: 1,
+								FailureThreshold: 3,
 							}, Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: 6379,

--- a/pkg/generate/examples/examples/valkey.go
+++ b/pkg/generate/examples/examples/valkey.go
@@ -49,7 +49,7 @@ func ValkeySts(namespace string) *appsv1.StatefulSet {
 							Image:           valkeyContainerImage,
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Command:         []string{"backup-restore-sidecar", "wait"},
-							LivenessProbe: &corev1.Probe{
+							StartupProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									Exec: &corev1.ExecAction{
 										Command: []string{"valkey-cli", "ping"},
@@ -59,7 +59,7 @@ func ValkeySts(namespace string) *appsv1.StatefulSet {
 								TimeoutSeconds:      1,
 								PeriodSeconds:       5,
 								SuccessThreshold:    1,
-								FailureThreshold:    3,
+								FailureThreshold:    360,
 							},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{


### PR DESCRIPTION
## Description
This PR initially started to tackle #14. 
I had a look at the setup of the wait and start containers and the probes for the database container and realized, that the problem is not so easy to solve.

### Kubernetes Probes
We used `livenessProbe` to wait for the database to come up. While this may work for small databases, it could accidentally terminate the database container while starting after a restore or under heavy load.
A better way for the initial `wait` would be the `startupProbe` in combination with a `readinessProbe`. The `startupProbe` can be configured with a higher initial threshold for bigger databases, with the 'readinessProbe' and `livenessProbe` kicking in after that. 

### Endless loop
Let's say we then have a successful initializer run and the database process starts with the restored data.
The sidecar now wants to start taking periodic backups and probes the database before starting the backupper.
This probe is currently an endless loop - and if for any reason the sidecar cannot connect (e.g., bad credentials), we might not notice this silent failure. 
Because the database itself is healthy, the K8s `readinessProbe` may succeed and serve user traffic, but our sidecar will silently sit there taking zero backups because it never reaches the backupper.

To expose this "silent failure", I introduced the backup_database_available Prometheus metric and an optional --probe-timeout flag. 

The modern K8s-native way is to alert on the metric (backup_database_available == 0). But if operators prefer, they can set the timeout to force the sidecar to crash and trigger a CrashLoopBackOff alert.
But this would mean that the database runs into a not-ready state as well, cutting off traffic and eventually being shut down.

I also tried to make the loops more resilient by adding a timeout.
Instead of logging all probe attempts, we also only log once a minute now.

### Interrupted restore
What if the restore ran into an unexpected error or got interrupted? Right now we only check if there is data already, but not if that's the leftovers of an attempted restore.
I propose to introduce a **dirty state** `.restore_in_progress` file right before starting the restore, which gets removed after a successful restore. 

This would allow us to look for a corrupted restore state when restarting after an unexpected shutdown and avoid starting the database on corrupt data.

What's your take on this @Gerrit91?


Closes #14 
Closes #130 

#### Used AI-Tools ✨

- Gemini 3.1 Pro was used with GH Copilot for research, autocomplete, batch edits and improving expressions in README
- Gemini 3.1 Pro was used to generate manual installation instructions based on the setup
- Claude Opus 4.6 generated a recreation detection for the restoreInterruptedFlow integration test
