### PR TITLE
Fix postgres incompatibilities for database upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ Probably, it does not make sense to use this project with large databases. Howev
 ## Supported Databases
 
 | Database  | Image        | Status | Upgrade Support |
-|-----------|--------------|:------:|:---------------:|
-| postgres  | >= 12-alpine |  beta  |        ✅        |
-| rethinkdb | >= 2.4.0     |  beta  |        ❌        |
-| ETCD      | >= 3.5       | alpha  |        ❌        |
-| redis     | >= 6.0       | alpha  |        ❌        |
-| keydb     | >= 6.0       | alpha  |        ❌        |
-| valkey    | >= 8.1       | alpha  |        ❌        |
-| localfs   |              | alpha  |        ❌        |
+| --------- | ------------ | :----: | :-------------: |
+| postgres  | >= 12-alpine |  beta  |       ✅        |
+| rethinkdb | >= 2.4.0     |  beta  |       ❌        |
+| ETCD      | >= 3.5       | alpha  |       ❌        |
+| redis     | >= 6.0       | alpha  |       ❌        |
+| keydb     | >= 6.0       | alpha  |       ❌        |
+| valkey    | >= 8.1       | alpha  |       ❌        |
+| localfs   |              | alpha  |       ❌        |
 
 Postgres also supports updates when using the TimescaleDB extension. Please consider the integration test for supported upgrade paths.
 
@@ -25,6 +25,8 @@ Postgres also supports updates when using the TimescaleDB extension. Please cons
 > The solution is to upgrade to a older 14.10-alpine which has the same icu-lib version as 12-alpine
 > and then update to 14.18-alpine or newer which does not require to run pg_upgrade.
 > It is also recommended to pin the original database to postgres:12.22-alpine to ensure the latest minor.
+> Upgrade from 14.18-alpine to 15-alpine is not possible because of version differences in ICU.
+> The solution is to upgrade to 15.13-alpine, followed by 15.18-alpine before upgrading to 17.10-alpine.
 
 ## Database Upgrades
 
@@ -41,7 +43,7 @@ To achieve this, `backup-restore-sidecar` saves the postgres binaries in the dat
 With `--compression-method` you can define how generated backups are compressed before stored at the storage provider. Available compression methods are:
 
 | compression-method | suffix   | comments                                                                                     |
-|--------------------|----------|----------------------------------------------------------------------------------------------|
+| ------------------ | -------- | -------------------------------------------------------------------------------------------- |
 | tar                | .tar     | no compression, best suited for already compressed content                                   |
 | targz              | .tar.gz  | tar and gzip, most commonly used, best compression ratio, average performance                |
 | tarlz4             | .tar.lz4 | tar and lz4, very fast compression/decompression speed compared to gz, slightly bigger files |

--- a/cmd/internal/database/postgres/upgrade.go
+++ b/cmd/internal/database/postgres/upgrade.go
@@ -202,23 +202,7 @@ func (db *Postgres) Upgrade(ctx context.Context) error {
 	cmd = exec.CommandContext(ctx, postgresUpgradeCmd, pgUpgradeArgs...) //nolint:gosec
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-
-	libDir := path.Join(oldPostgresBinDir, "lib")
-	if info, err := os.Stat(libDir); err == nil && info.IsDir() {
-		db.log.Info("bundled ICU libraries found, setting LD_LIBRARY_PATH for pg_upgrade", "directory", libDir)
-		env := os.Environ()
-		var filtered []string
-		for _, e := range env {
-			if !strings.HasPrefix(e, "LD_LIBRARY_PATH=") {
-				filtered = append(filtered, e)
-			}
-		}
-		filtered = append(filtered, "LD_LIBRARY_PATH="+libDir)
-		cmd.Env = filtered
-	} else {
-		cmd.Env = os.Environ()
-	}
-
+	cmd.Env = os.Environ()
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Credential: &syscall.Credential{Uid: uint32(uid)}, // nolint:gosec
 	}
@@ -370,11 +354,6 @@ func (db *Postgres) copyPostgresBinaries(ctx context.Context, override bool) err
 		return fmt.Errorf("unable to copy pg bin dir: %w", err)
 	}
 
-	err = db.copyPostgresICULibraries(binDir, pgBinDir)
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -400,67 +379,4 @@ func (db *Postgres) restoreOldPostgresBinaries(src, dst string) error {
 
 		return nil
 	})
-}
-
-func (db *Postgres) copyPostgresICULibraries(binDir, pgBinDir string) error {
-	postgresBinary := path.Join(binDir, "postgres")
-	if _, err := os.Stat(postgresBinary); err != nil {
-		return err
-	}
-
-	cmd := exec.Command("ldd", postgresBinary)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		db.log.Warn("unable to detect ICU libraries for postgres binary, upgrade may fail later if ICU versions differ", "error", err)
-		return nil
-	}
-
-	libDir := path.Join(pgBinDir, "lib")
-	err = os.MkdirAll(libDir, 0755)
-	if err != nil {
-		return fmt.Errorf("unable to create lib directory: %w", err)
-	}
-
-	copied := 0
-	for _, line := range strings.Split(string(out), "\n") {
-		line = strings.TrimSpace(line)
-		if !strings.Contains(line, "libicu") {
-			continue
-		}
-
-		libPath := extractLibraryPath(line)
-		if libPath == "" {
-			continue
-		}
-
-		db.log.Info("copying ICU library for later upgrade compatibility", "library", libPath)
-
-		copy := exec.Command("cp", "-avL", libPath, libDir)
-		copy.Stdout = os.Stdout
-		copy.Stderr = os.Stderr
-		err := copy.Run()
-		if err != nil {
-			db.log.Warn("unable to copy ICU library", "library", libPath, "error", err)
-			continue
-		}
-		copied++
-	}
-
-	if copied == 0 {
-		db.log.Warn("no ICU libraries were copied, upgrade may fail if ICU versions differ between postgres images")
-	}
-
-	return nil
-}
-
-func extractLibraryPath(line string) string {
-	if _, after, found := strings.Cut(line, "=>"); found {
-		line = after
-	}
-
-	if before, _, found := strings.Cut(line, " (0x"); found {
-		line = before
-	}
-
-	return strings.TrimSpace(line)
 }

--- a/cmd/internal/database/postgres/upgrade.go
+++ b/cmd/internal/database/postgres/upgrade.go
@@ -202,7 +202,23 @@ func (db *Postgres) Upgrade(ctx context.Context) error {
 	cmd = exec.CommandContext(ctx, postgresUpgradeCmd, pgUpgradeArgs...) //nolint:gosec
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Env = os.Environ()
+
+	libDir := path.Join(oldPostgresBinDir, "lib")
+	if info, err := os.Stat(libDir); err == nil && info.IsDir() {
+		db.log.Info("bundled ICU libraries found, setting LD_LIBRARY_PATH for pg_upgrade", "directory", libDir)
+		env := os.Environ()
+		var filtered []string
+		for _, e := range env {
+			if !strings.HasPrefix(e, "LD_LIBRARY_PATH=") {
+				filtered = append(filtered, e)
+			}
+		}
+		filtered = append(filtered, "LD_LIBRARY_PATH="+libDir)
+		cmd.Env = filtered
+	} else {
+		cmd.Env = os.Environ()
+	}
+
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Credential: &syscall.Credential{Uid: uint32(uid)}, // nolint:gosec
 	}
@@ -354,6 +370,11 @@ func (db *Postgres) copyPostgresBinaries(ctx context.Context, override bool) err
 		return fmt.Errorf("unable to copy pg bin dir: %w", err)
 	}
 
+	err = db.copyPostgresICULibraries(binDir, pgBinDir)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -379,4 +400,67 @@ func (db *Postgres) restoreOldPostgresBinaries(src, dst string) error {
 
 		return nil
 	})
+}
+
+func (db *Postgres) copyPostgresICULibraries(binDir, pgBinDir string) error {
+	postgresBinary := path.Join(binDir, "postgres")
+	if _, err := os.Stat(postgresBinary); err != nil {
+		return err
+	}
+
+	cmd := exec.Command("ldd", postgresBinary)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		db.log.Warn("unable to detect ICU libraries for postgres binary, upgrade may fail later if ICU versions differ", "error", err)
+		return nil
+	}
+
+	libDir := path.Join(pgBinDir, "lib")
+	err = os.MkdirAll(libDir, 0755)
+	if err != nil {
+		return fmt.Errorf("unable to create lib directory: %w", err)
+	}
+
+	copied := 0
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.Contains(line, "libicu") {
+			continue
+		}
+
+		libPath := extractLibraryPath(line)
+		if libPath == "" {
+			continue
+		}
+
+		db.log.Info("copying ICU library for later upgrade compatibility", "library", libPath)
+
+		copy := exec.Command("cp", "-avL", libPath, libDir)
+		copy.Stdout = os.Stdout
+		copy.Stderr = os.Stderr
+		err := copy.Run()
+		if err != nil {
+			db.log.Warn("unable to copy ICU library", "library", libPath, "error", err)
+			continue
+		}
+		copied++
+	}
+
+	if copied == 0 {
+		db.log.Warn("no ICU libraries were copied, upgrade may fail if ICU versions differ between postgres images")
+	}
+
+	return nil
+}
+
+func extractLibraryPath(line string) string {
+	if _, after, found := strings.Cut(line, "=>"); found {
+		line = after
+	}
+
+	if before, _, found := strings.Cut(line, " (0x"); found {
+		line = before
+	}
+
+	return strings.TrimSpace(line)
 }

--- a/integration/postgres_test.go
+++ b/integration/postgres_test.go
@@ -51,11 +51,12 @@ func Test_Postgres_Upgrade(t *testing.T) {
 			// Upgrade from 12-alpine to 13-alpine is not possible because of library differences in icu-lib.
 			// The solution is to upgrade to a older 14.10-alpine which has the same icu-lib version as 12-alpine
 			// and then update to 14.18-alpine or newer which does not require to run pg_upgrade.
-			// "postgres:13-alpine",
 			"postgres:14.10-alpine",
 			"postgres:14.18-alpine",
-			"postgres:15-alpine",
-			"postgres:17-alpine",
+			// Upgrade from 14.18-alpine to 15-alpine is not possible because of version differences in ICU.
+			// As a solution explicit versions are used for performing the upgrades that share the same ICU version.
+			"postgres:15.13-alpine",
+			"postgres:17.6-alpine",
 		},
 	})
 }

--- a/integration/postgres_test.go
+++ b/integration/postgres_test.go
@@ -48,11 +48,15 @@ func Test_Postgres_Upgrade(t *testing.T) {
 		},
 		databaseImages: []string{
 			"postgres:12-alpine",
-			"postgres:13-alpine",
-			"postgres:14-alpine",
-			"postgres:15-alpine",
-			"postgres:16-alpine",
-			"postgres:17-alpine",
+			// Upgrade from 12-alpine to 13-alpine is not possible because of library differences in icu-lib.
+			// The solution is to upgrade to a older 14.10-alpine which has the same icu-lib version as 12-alpine
+			// and then update to 14.18-alpine or newer which does not require to run pg_upgrade.
+			"postgres:14.10-alpine",
+			"postgres:14.18-alpine",
+			// Upgrade from 14.18-alpine to 15-alpine is not possible because of version differences in ICU.
+			// As a solution explicit versions are used for performing the upgrades that share the same ICU version.
+			"postgres:15.13-alpine",
+			"postgres:17.6-alpine",
 		},
 	})
 }

--- a/integration/postgres_test.go
+++ b/integration/postgres_test.go
@@ -54,9 +54,9 @@ func Test_Postgres_Upgrade(t *testing.T) {
 			"postgres:14.10-alpine",
 			"postgres:14.18-alpine",
 			// Upgrade from 14.18-alpine to 15-alpine is not possible because of version differences in ICU.
-			// As a solution explicit versions are used for performing the upgrades that share the same ICU version.
 			"postgres:15.13-alpine",
-			"postgres:17.6-alpine",
+			"postgres:15.18-alpine",
+			"postgres:17.10-alpine",
 		},
 	})
 }

--- a/integration/postgres_test.go
+++ b/integration/postgres_test.go
@@ -54,6 +54,7 @@ func Test_Postgres_Upgrade(t *testing.T) {
 			"postgres:14.10-alpine",
 			"postgres:14.18-alpine",
 			// Upgrade from 14.18-alpine to 15-alpine is not possible because of version differences in ICU.
+			// The solution is to upgrade to 15.13-alpine, followed by 15.18-alpine before upgrading to 17.10-alpine.
 			"postgres:15.13-alpine",
 			"postgres:15.18-alpine",
 			"postgres:17.10-alpine",

--- a/integration/postgres_test.go
+++ b/integration/postgres_test.go
@@ -48,15 +48,11 @@ func Test_Postgres_Upgrade(t *testing.T) {
 		},
 		databaseImages: []string{
 			"postgres:12-alpine",
-			// Upgrade from 12-alpine to 13-alpine is not possible because of library differences in icu-lib.
-			// The solution is to upgrade to a older 14.10-alpine which has the same icu-lib version as 12-alpine
-			// and then update to 14.18-alpine or newer which does not require to run pg_upgrade.
-			"postgres:14.10-alpine",
-			"postgres:14.18-alpine",
-			// Upgrade from 14.18-alpine to 15-alpine is not possible because of version differences in ICU.
-			// As a solution explicit versions are used for performing the upgrades that share the same ICU version.
-			"postgres:15.13-alpine",
-			"postgres:17.6-alpine",
+			"postgres:13-alpine",
+			"postgres:14-alpine",
+			"postgres:15-alpine",
+			"postgres:16-alpine",
+			"postgres:17-alpine",
 		},
 	})
 }


### PR DESCRIPTION
## Description

This pull request is necessary to fix failing CI tests.
It changes the postgres versions used for testing postgres upgrades, due to incompatible ICU versions within the images. The upgrades are performed as follows:
`postgres:14.18-alpine` -> `postgres:15.13-alpine` -> `postgres:15.18-alpine` -> `postgres:17.10-alpine` 


#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- Qwen3.6

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
