### PR TITLE
Make NewerNoncurrentVersions optional in lifecycle policy for s3 backend

### DIFF
--- a/cmd/internal/backup/providers/s3/s3.go
+++ b/cmd/internal/backup/providers/s3/s3.go
@@ -200,9 +200,13 @@ func (b *BackupProviderS3) EnsureBackupBucket(ctx context.Context) error {
 
 	lifecycleRuleID := aws.String(b.config.ObjectPrefix + "-backup-restore-lifecycle")
 
-	noncurrentExpiration := &types.NoncurrentVersionExpiration{
-		NewerNoncurrentVersions: &b.config.ObjectsToKeep,
+	noncurrentExpiration := &types.NoncurrentVersionExpiration{}
+
+	if b.config.ObjectsToKeep != 0 {
+		noncurrentExpiration.NewerNoncurrentVersions = &b.config.ObjectsToKeep
+
 	}
+
 	if b.config.ObjectDaysToKeep != nil {
 		noncurrentExpiration.NoncurrentDays = b.config.ObjectDaysToKeep
 	}

--- a/cmd/internal/backup/providers/s3/s3.go
+++ b/cmd/internal/backup/providers/s3/s3.go
@@ -48,7 +48,7 @@ type BackupProviderConfigS3 struct {
 	InsecureSkipVerify         *bool
 	TrustedCaCert              *string
 	ObjectPrefix               string
-	ObjectsToKeep              int32
+	ObjectsToKeep              *int32
 	ObjectDaysToKeep           *int32
 	FS                         afero.Fs
 	Suffix                     string
@@ -202,9 +202,8 @@ func (b *BackupProviderS3) EnsureBackupBucket(ctx context.Context) error {
 
 	noncurrentExpiration := &types.NoncurrentVersionExpiration{}
 
-	if b.config.ObjectsToKeep != 0 {
-		noncurrentExpiration.NewerNoncurrentVersions = &b.config.ObjectsToKeep
-
+	if b.config.ObjectsToKeep != nil {
+		noncurrentExpiration.NewerNoncurrentVersions = b.config.ObjectsToKeep
 	}
 
 	if b.config.ObjectDaysToKeep != nil {

--- a/cmd/internal/backup/providers/s3/s3.go
+++ b/cmd/internal/backup/providers/s3/s3.go
@@ -20,7 +20,6 @@ import (
 	"github.com/spf13/afero"
 
 	"github.com/metal-stack/backup-restore-sidecar/cmd/internal/backup/providers"
-	"github.com/metal-stack/backup-restore-sidecar/pkg/constants"
 )
 
 const (
@@ -88,9 +87,6 @@ func New(log *slog.Logger, cfg *BackupProviderConfigS3) (*BackupProviderS3, erro
 		return nil, errors.New("s3 backup provider requires a provider config")
 	}
 
-	if cfg.ObjectsToKeep == 0 {
-		cfg.ObjectsToKeep = constants.DefaultObjectsToKeep
-	}
 	if cfg.BackupName == "" {
 		cfg.BackupName = defaultBackupName
 	}

--- a/cmd/internal/backup/providers/s3/s3_integration_test.go
+++ b/cmd/internal/backup/providers/s3/s3_integration_test.go
@@ -73,6 +73,7 @@ func Test_BackupProviderS3(t *testing.T) {
 		ObjectPrefix:  prefix,
 		FS:            fs,
 		Suffix:        compressor.Extension(),
+		ObjectsToKeep: constants.DefaultObjectsToKeep,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, p)

--- a/cmd/internal/backup/providers/s3/s3_integration_test.go
+++ b/cmd/internal/backup/providers/s3/s3_integration_test.go
@@ -73,7 +73,7 @@ func Test_BackupProviderS3(t *testing.T) {
 		ObjectPrefix:  prefix,
 		FS:            fs,
 		Suffix:        compressor.Extension(),
-		ObjectsToKeep: constants.DefaultObjectsToKeep,
+		ObjectsToKeep: new(int32(constants.DefaultObjectsToKeep)),
 	})
 	require.NoError(t, err)
 	require.NotNil(t, p)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -372,7 +372,7 @@ func init() {
 	startCmd.Flags().StringP(backupProviderFlg, "", "", "the name of the backup provider [gcp|s3|local]")
 	startCmd.Flags().StringP(backupCronScheduleFlg, "", "*/3 * * * *", "cron schedule for taking backups periodically")
 
-	startCmd.Flags().IntP(objectsToKeepFlg, "", constants.DefaultObjectsToKeep, "the number of objects to keep at the cloud provider bucket. Used in the bucket lifecycle configuration as NumNewerVersions for gcp or NewerNoncurrentVersions for s3 (default: 20)")
+	startCmd.Flags().IntP(objectsToKeepFlg, "", 0, "the number of objects to keep at the cloud provider bucket. Used in the bucket lifecycle configuration as NumNewerVersions for gcp or NewerNoncurrentVersions for s3 (optional)")
 	startCmd.Flags().IntP(objectDaysToKeepFlg, "", 0, "the number of days to keep objects at the cloud provider bucket for the s3 backend. Used as NoncurrentDays in the bucket lifecycle configuration for s3 (optional)")
 	startCmd.Flags().StringP(objectPrefixFlg, "", "", "the prefix to store the object in the cloud provider bucket")
 
@@ -591,20 +591,22 @@ func initBackupProvider() error {
 		)
 	case "s3":
 		bkpConfig := &s3.BackupProviderConfigS3{
-			ObjectPrefix:  viper.GetString(objectPrefixFlg),
-			ObjectsToKeep: viper.GetInt32(objectsToKeepFlg),
-			Region:        viper.GetString(s3RegionFlg),
-			BucketName:    viper.GetString(s3BucketNameFlg),
-			Endpoint:      viper.GetString(s3EndpointFlg),
-			AccessKey:     viper.GetString(s3AccessKeyFlg),
-			SecretKey:     viper.GetString(s3SecretKeyFlg),
-			Suffix:        suffix,
+			ObjectPrefix: viper.GetString(objectPrefixFlg),
+			Region:       viper.GetString(s3RegionFlg),
+			BucketName:   viper.GetString(s3BucketNameFlg),
+			Endpoint:     viper.GetString(s3EndpointFlg),
+			AccessKey:    viper.GetString(s3AccessKeyFlg),
+			SecretKey:    viper.GetString(s3SecretKeyFlg),
+			Suffix:       suffix,
 		}
 		if viper.IsSet(s3InsecureSkipVerify) {
 			bkpConfig.InsecureSkipVerify = new(viper.GetBool(s3InsecureSkipVerify))
 		}
 		if viper.IsSet(s3TrustedCaCert) {
 			bkpConfig.TrustedCaCert = new(viper.GetString(s3TrustedCaCert))
+		}
+		if viper.IsSet(objectsToKeepFlg) && viper.GetInt(objectsToKeepFlg) != 0 {
+			bkpConfig.ObjectsToKeep = new(viper.GetInt32(objectsToKeepFlg))
 		}
 		if viper.IsSet(objectDaysToKeepFlg) && viper.GetInt(objectDaysToKeepFlg) != 0 {
 			bkpConfig.ObjectDaysToKeep = new(viper.GetInt32(objectDaysToKeepFlg))

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -372,7 +372,7 @@ func init() {
 	startCmd.Flags().StringP(backupProviderFlg, "", "", "the name of the backup provider [gcp|s3|local]")
 	startCmd.Flags().StringP(backupCronScheduleFlg, "", "*/3 * * * *", "cron schedule for taking backups periodically")
 
-	startCmd.Flags().IntP(objectsToKeepFlg, "", constants.DefaultObjectsToKeep, "the number of objects to keep at the cloud provider bucket")
+	startCmd.Flags().IntP(objectsToKeepFlg, "", 0, "the number of objects to keep at the cloud provider bucket")
 	startCmd.Flags().StringP(objectPrefixFlg, "", "", "the prefix to store the object in the cloud provider bucket")
 
 	startCmd.Flags().StringP(gcpBucketNameFlg, "", "", "the name of the gcp backup bucket")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -372,7 +372,8 @@ func init() {
 	startCmd.Flags().StringP(backupProviderFlg, "", "", "the name of the backup provider [gcp|s3|local]")
 	startCmd.Flags().StringP(backupCronScheduleFlg, "", "*/3 * * * *", "cron schedule for taking backups periodically")
 
-	startCmd.Flags().IntP(objectsToKeepFlg, "", 0, "the number of objects to keep at the cloud provider bucket")
+	startCmd.Flags().IntP(objectsToKeepFlg, "", constants.DefaultObjectsToKeep, "the number of objects to keep at the cloud provider bucket. Used in the bucket lifecycle configuration as NumNewerVersions for gcp or NewerNoncurrentVersions for s3")
+	startCmd.Flags().IntP(objectDaysToKeepFlg, "", 0, "the number of days to keep objects at the cloud provider bucket for the s3 backend. Used as NoncurrentDays in the bucket lifecycle configuration for s3")
 	startCmd.Flags().StringP(objectPrefixFlg, "", "", "the prefix to store the object in the cloud provider bucket")
 
 	startCmd.Flags().StringP(gcpBucketNameFlg, "", "", "the name of the gcp backup bucket")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -372,8 +372,10 @@ func init() {
 	startCmd.Flags().StringP(backupProviderFlg, "", "", "the name of the backup provider [gcp|s3|local]")
 	startCmd.Flags().StringP(backupCronScheduleFlg, "", "*/3 * * * *", "cron schedule for taking backups periodically")
 
-	startCmd.Flags().IntP(objectsToKeepFlg, "", constants.DefaultObjectsToKeep, "the number of objects to keep at the cloud provider bucket. Used in the bucket lifecycle configuration as NumNewerVersions for gcp or NewerNoncurrentVersions for s3")
-	startCmd.Flags().IntP(objectDaysToKeepFlg, "", 0, "the number of days to keep objects at the cloud provider bucket for the s3 backend. Used as NoncurrentDays in the bucket lifecycle configuration for s3")
+	startCmd.Flags().IntP(objectsToKeepFlg, "", constants.DefaultObjectsToKeep, "the number of objects to keep at the cloud provider bucket. Used in the bucket lifecycle configuration as NumNewerVersions for gcp or NewerNoncurrentVersions for s3 (default: 20)")
+	if viper.IsSet(objectDaysToKeepFlg) && viper.GetInt(objectDaysToKeepFlg) != 0 {
+		startCmd.Flags().IntP(objectDaysToKeepFlg, "", 0, "the number of days to keep objects at the cloud provider bucket for the s3 backend. Used as NoncurrentDays in the bucket lifecycle configuration for s3 (optional)")
+	}
 	startCmd.Flags().StringP(objectPrefixFlg, "", "", "the prefix to store the object in the cloud provider bucket")
 
 	startCmd.Flags().StringP(gcpBucketNameFlg, "", "", "the name of the gcp backup bucket")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -373,9 +373,7 @@ func init() {
 	startCmd.Flags().StringP(backupCronScheduleFlg, "", "*/3 * * * *", "cron schedule for taking backups periodically")
 
 	startCmd.Flags().IntP(objectsToKeepFlg, "", constants.DefaultObjectsToKeep, "the number of objects to keep at the cloud provider bucket. Used in the bucket lifecycle configuration as NumNewerVersions for gcp or NewerNoncurrentVersions for s3 (default: 20)")
-	if viper.IsSet(objectDaysToKeepFlg) && viper.GetInt(objectDaysToKeepFlg) != 0 {
-		startCmd.Flags().IntP(objectDaysToKeepFlg, "", 0, "the number of days to keep objects at the cloud provider bucket for the s3 backend. Used as NoncurrentDays in the bucket lifecycle configuration for s3 (optional)")
-	}
+	startCmd.Flags().IntP(objectDaysToKeepFlg, "", 0, "the number of days to keep objects at the cloud provider bucket for the s3 backend. Used as NoncurrentDays in the bucket lifecycle configuration for s3 (optional)")
 	startCmd.Flags().StringP(objectPrefixFlg, "", "", "the prefix to store the object in the cloud provider bucket")
 
 	startCmd.Flags().StringP(gcpBucketNameFlg, "", "", "the name of the gcp backup bucket")
@@ -608,7 +606,7 @@ func initBackupProvider() error {
 		if viper.IsSet(s3TrustedCaCert) {
 			bkpConfig.TrustedCaCert = new(viper.GetString(s3TrustedCaCert))
 		}
-		if viper.IsSet(objectDaysToKeepFlg) {
+		if viper.IsSet(objectDaysToKeepFlg) && viper.GetInt(objectDaysToKeepFlg) != 0 {
 			bkpConfig.ObjectDaysToKeep = new(viper.GetInt32(objectDaysToKeepFlg))
 		}
 		if viper.IsSet(s3RequestChecksumCalculation) {


### PR DESCRIPTION
## Description

Removes the code to always include a default of 20 objects to keep for `NewerNoncurrentVersions` applied to the lifecycle rule of a backup bucket on s3 backends. This pull requests changes the implementation for the s3 backend without changes to the gcp backend.

This change is necessary, becuase some s3 backends have limits of e.g. 100 `NewerNoncurrentVersions`. Depending on the configuration for the backup frequency and the number of days to keep backups, this can lead to backups getting cleaned up earlier then expected. However, completely removing the `NewerNoncurrentVersions` configuration and just configuring `NoncurrentDays` is an alternative. Until now this was not possible.

Changes to the s3 backend:
If using the `backup-restore-sidecar` component directly its behavior changes, because a value for `NoncurrentDays` via the flag: `object-max-keep` need to be provided explicitly. Until now a default of 20 was configured.
If using the `backup-restore-sidecar` component in the context of a metal-stack deployment, check the default values applied via the ansible variables.


```BREAKING_CHANGE
It is now possible to configure `NoncurrentDays` also via flag, as follow up from #141. The s3 backend can be configured with `NewerNoncurrentVersions` as well as `NoncurrentDays`. Both can be used together, independently or completely removed from the lifecycle rule. The always applied default for `NewerNoncurrentVersions` was removed. So make sure to configure it accordingly, if not already configured in your deployment.
```

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- None

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
